### PR TITLE
Format Columns in Table

### DIFF
--- a/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentTable/MaterialLengthAdjustmentTable/MaterialLengthAdjustmentTable.tsx
+++ b/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentTable/MaterialLengthAdjustmentTable/MaterialLengthAdjustmentTable.tsx
@@ -12,7 +12,7 @@ import Row from '../../../_global/Table/Row/Row';
 import './MaterialLengthAdjustmentTable.scss'
 import { PageSelect } from '../../../_global/Table/PageSelect/PageSelect';
 import { SearchResult } from '@shared/types/http';
-import { getDateFromIsoStr } from '@ui/utils/dateTime';
+import { getDateTimeFromIsoStr } from '@ui/utils/dateTime';
 
 type TODO = any;
 
@@ -23,16 +23,16 @@ const columns = [
     id: 'material.name',
     header: 'Material Name',
   }),
-  columnHelper.accessor('length', {
+  columnHelper.accessor(row => (row.length && row.length > 0) ? `${row.length}` : `(${Math.abs(row.length)})`, {
     header: 'Length',
   }),
   columnHelper.accessor('notes', {
     header: 'Notes',
   }),
-  columnHelper.accessor(row => getDateFromIsoStr(row.updatedAt), {
+  columnHelper.accessor(row => getDateTimeFromIsoStr(row.updatedAt), {
     header: 'Updated'
   }),
-  columnHelper.accessor(row => getDateFromIsoStr(row.createdAt), {
+  columnHelper.accessor(row => getDateTimeFromIsoStr(row.createdAt), {
     header: 'Created'
   }),
   columnHelper.display({

--- a/application/react/_utils/dateTime.ts
+++ b/application/react/_utils/dateTime.ts
@@ -2,7 +2,7 @@ export const getDateFromIsoStr = (dateAsString: string | undefined): string => {
   if (!dateAsString) {
     return ''
   }
-  return new Date(dateAsString).toISOString().substring(0, 10)
+  return new Date(dateAsString).toLocaleString('en-US', { year: 'numeric', month: 'short', day: '2-digit' });
 }
 
 export const getDateTimeFromIsoStr = (dateTimeAsString: string | undefined): string => {
@@ -10,5 +10,5 @@ export const getDateTimeFromIsoStr = (dateTimeAsString: string | undefined): str
     return ''
   }
 
-  return new Date(dateTimeAsString).toLocaleString()
+  return new Date(dateTimeAsString).toLocaleString('en-US', { year: 'numeric', month: 'short', day: '2-digit', hour: 'numeric', minute: 'numeric' });
 }


### PR DESCRIPTION
# Description

Previously we had dates and dateTime columns that were not being formatted.

I.e:

`2022-04-18T23:51:56.714Z`
`2025-10-25`
`ect`

were being printed

This PR adds helper methods such that:
  1. Dates are formatted as: `Dec 30, 2027`
  2. DateTimes are formatted as: `Dec 01, 2023, 10:50 AM`