### PR TITLE
Add Units to Input Fields

### DIFF
--- a/application/react/Customer/Contact/ContactForm/ContactForm.tsx
+++ b/application/react/Customer/Contact/ContactForm/ContactForm.tsx
@@ -5,6 +5,7 @@ import { AddressFormAttributes } from '../../../Address/AddressForm/AddressForm'
 import { Input } from '../../../_global/FormInputs/Input/Input';
 import { ShippingLocationFormAttributes } from '../../../ShippingLocation/ShippingLocationForm/ShippingLocationForm';
 import { CustomSelect, SelectOption } from '../../../_global/FormInputs/CustomSelect/CustomSelect';
+import { TextArea } from '../../../_global/FormInputs/TextArea/TextArea';
 
 interface Props {
   onSubmit: (contact: any) => void, 
@@ -71,7 +72,7 @@ export const ContactForm = (props: Props) => {
               errors={errors}
           />
         </div>
-        <Input
+        <TextArea
             attribute='notes'
             label="Notes"
             register={register}

--- a/application/react/Customer/CustomerForm/CustomerForm.tsx
+++ b/application/react/Customer/CustomerForm/CustomerForm.tsx
@@ -54,7 +54,7 @@ export const CustomerForm = () => {
   }, [billingLocations, shippingLocations, businessLocations]);
 
   const preloadFormData = async () => {
-    const creditTermSearchResults = await performTextSearch<ICreditTerm>('/customers', { query: '', limit: '100' })
+    const creditTermSearchResults = await performTextSearch<ICreditTerm>('/credit-terms/search', { query: '', limit: '100' })
     const creditTerms = creditTermSearchResults.results
   
     setCreditTerms(creditTerms.map((creditTerm : ICreditTerm) => (
@@ -176,6 +176,7 @@ export const CustomerForm = () => {
                     register={register}
                     isRequired={true}
                     errors={errors}
+                    unit='@Storm'
                   />
                 </div>
                 <Input

--- a/application/react/Customer/CustomerForm/CustomerForm.tsx
+++ b/application/react/Customer/CustomerForm/CustomerForm.tsx
@@ -23,6 +23,7 @@ import { MongooseId } from '../../_types/typeAliases';
 import { performTextSearch } from '../../_queries/_common';
 import { ICreditTerm } from '@shared/types/models';
 import { CustomSelect, SelectOption } from '../../_global/FormInputs/CustomSelect/CustomSelect';
+import { TextArea } from '../../_global/FormInputs/TextArea/TextArea';
 
 const customerTableUrl = '/react-ui/tables/customer'
 
@@ -179,7 +180,7 @@ export const CustomerForm = () => {
                     unit='@Storm'
                   />
                 </div>
-                <Input
+                <TextArea
                     attribute='notes'
                     label="Notes"
                     register={register}

--- a/application/react/Die/DieForm/DieForm.tsx
+++ b/application/react/Die/DieForm/DieForm.tsx
@@ -13,6 +13,7 @@ import { dieVendors } from '../../../api/enums/dieVendorsEnum';
 import { dieMagCylinders } from '../../../api/enums/dieMagCylindersEnum';
 import { dieStatuses } from '../../../api/enums/dieStatusesEnum';
 import { CustomSelect } from '../../_global/FormInputs/CustomSelect/CustomSelect';
+import { TextArea } from '../../_global/FormInputs/TextArea/TextArea';
 
 const dieTableUrl = '/react-ui/tables/die'
 
@@ -156,7 +157,7 @@ export const DieForm = () => {
               isRequired={true}
               control={control}
             />
-            <Input
+            <TextArea
               attribute='notes'
               label="Notes"
               register={register}

--- a/application/react/Die/DieForm/DieForm.tsx
+++ b/application/react/Die/DieForm/DieForm.tsx
@@ -57,7 +57,7 @@ export const DieForm = () => {
       leftAndRight: die.leftAndRight,
       facestock: die.facestock,
       liner: die.liner,
-      specialType: die.specialType,
+      specialType: die.specialType || '',
       serialNumber: die.serialNumber,
       status: die.status,
       quantity: die.quantity
@@ -114,6 +114,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+              unit='@storm'
             />
             <Input
               attribute='sizeAround'
@@ -121,6 +122,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+              unit='@storm'
             />
             <Input
               attribute='numberAcross'
@@ -128,6 +130,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+                unit='@storm'
             />
             <Input
               attribute='numberAround'
@@ -135,6 +138,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+              unit='@storm'
             />
             <Input
               attribute='gear'
@@ -165,6 +169,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+              fieldType='currency'
             />
             <CustomSelect
               attribute='vendor'
@@ -190,6 +195,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+              unit='@storm'
             />
             <Input
               attribute='topAndBottom'
@@ -197,6 +203,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+              unit='@storm'
             />
             <Input
               attribute='leftAndRight'
@@ -204,6 +211,7 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
+              unit='@storm'
             />
             <Input
               attribute='facestock'

--- a/application/react/Material/MaterialForm/MaterialForm.tsx
+++ b/application/react/Material/MaterialForm/MaterialForm.tsx
@@ -168,6 +168,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='weight'
@@ -175,6 +176,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='costPerMsi'
@@ -182,6 +184,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  fieldType='currency'
                 />
                 <Input
                   attribute='freightCostPerMsi'
@@ -189,6 +192,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  fieldType='currency'
                 />
                 <Input
                   attribute='width'
@@ -196,6 +200,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='faceColor'
@@ -217,6 +222,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  fieldType='currency'
                 />
                 <Input
                   attribute='minFootageAlertThreshold'
@@ -224,6 +230,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='description'
@@ -252,6 +259,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='facesheetWeightPerMsi'
@@ -259,6 +267,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='adhesiveWeightPerMsi'
@@ -266,6 +275,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='linerWeightPerMsi'
@@ -273,6 +283,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <MaterialLocationSelector
                   setValue={setValue}
@@ -291,6 +302,7 @@ export const MaterialForm = () => {
                   register={register}
                   isRequired={true}
                   errors={errors}
+                  unit='@storm'
                 />
                 <Input
                   attribute='image'
@@ -335,7 +347,6 @@ export const MaterialForm = () => {
                   errors={errors}
                   control={control}
                 />
-
               </div>
               <button className='create-entry submit-button' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>

--- a/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
+++ b/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
@@ -94,6 +94,7 @@ export const MaterialLengthAdjustmentForm = () => {
               register={register}
               isRequired={true}
               errors={errors}
+              unit='@storm'
             />
             <Input
               attribute='notes'

--- a/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
+++ b/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
@@ -11,6 +11,7 @@ import { IMaterial, IMaterialLengthAdjustment } from '@shared/types/models.ts';
 import { performTextSearch } from '../../_queries/_common.ts';
 import { SearchResult } from '@shared/types/http.ts';
 import { CustomSelect, SelectOption } from '../../_global/FormInputs/CustomSelect/CustomSelect.tsx';
+import { TextArea } from '../../_global/FormInputs/TextArea/TextArea.tsx';
 
 
 export const MaterialLengthAdjustmentForm = () => {
@@ -96,7 +97,7 @@ export const MaterialLengthAdjustmentForm = () => {
               errors={errors}
               unit='@storm'
             />
-            <Input
+            <TextArea
               attribute='notes'
               label="Notes"
               register={register}

--- a/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
+++ b/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
@@ -165,6 +165,7 @@ export const MaterialOrderForm = () => {
                 register={register}
                 isRequired={true}
                 errors={errors}
+                unit='@storm'
             />
             <Input
                 attribute='totalRolls'
@@ -179,6 +180,7 @@ export const MaterialOrderForm = () => {
                 register={register}
                 isRequired={true}
                 errors={errors}
+                fieldType='currency'
             />
             <Input
                 attribute='hasArrived'
@@ -209,6 +211,7 @@ export const MaterialOrderForm = () => {
                 register={register}
                 isRequired={true}
                 errors={errors}
+                fieldType='currency'
             />
             <Input
                 attribute='fuelCharge'
@@ -216,6 +219,7 @@ export const MaterialOrderForm = () => {
                 register={register}
                 isRequired={true}
                 errors={errors}
+                fieldType='currency'
             />
             <button className='create-entry submit-button' type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>

--- a/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
+++ b/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
@@ -15,6 +15,7 @@ import { IMaterialOrder } from '../../../api/models/materialOrder'
 import { performTextSearch } from '../../_queries/_common.ts';
 import { IMaterial, IVendor } from '@shared/types/models.ts';
 import { CustomSelect, SelectOption } from '../../_global/FormInputs/CustomSelect/CustomSelect.tsx';
+import { TextArea } from '../../_global/FormInputs/TextArea/TextArea.tsx';
 
 const materialOrderTableUrl = '/react-ui/tables/material-order'
 
@@ -190,7 +191,7 @@ export const MaterialOrderForm = () => {
                 errors={errors}
                 fieldType='checkbox'
             />
-            <Input
+            <TextArea
                 attribute='notes'
                 label="Notes"
                 register={register}

--- a/application/react/Vendor/VendorForm/VendorForm.tsx
+++ b/application/react/Vendor/VendorForm/VendorForm.tsx
@@ -11,6 +11,7 @@ import { Input } from '../../_global/FormInputs/Input/Input';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { getOneVendor } from '../../_queries/vendors';
+import { TextArea } from '../../_global/FormInputs/TextArea/TextArea';
 
 const vendorTableUrl = '/react-ui/tables/vendor'
 
@@ -117,7 +118,7 @@ export const VendorForm = () => {
                       isRequired={true}
                       errors={errors}
                   />
-                  <Input
+                  <TextArea
                     attribute='notes'
                     label="Notes"
                     register={register}

--- a/application/react/_global/FormInputs/Input/Input.tsx
+++ b/application/react/_global/FormInputs/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref } from 'react';
+import React, { forwardRef } from 'react';
 import './Input'
 import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage';
 import { FieldErrors, FieldValues, Path, UseFormRegister } from 'react-hook-form';
@@ -12,9 +12,10 @@ type Props<T extends FieldValues> = {
   isRequired?: boolean
   additionalRegisterOptions?: any
   onChange?: () => void,
-  fieldType?: 'text' | 'checkbox' | 'date' | 'password',
+  fieldType?: 'text' | 'checkbox' | 'date' | 'password' | 'currency' | 'percent',
   ref?: any,
   dataAttributes?: { [key: `data-${string}`]: string }
+  unit?: string
 }
 
 /* This "solution" was found here to solve hard-to-fix typescript errors resulting from usage of forwardRef(..): https://stackoverflow.com/a/73795494 */
@@ -24,16 +25,18 @@ interface WithForwardRefType extends React.FC<Props<FieldValues>>  {
 
 /* @Gavin More client side validation rules can be configured in react-hook-form. see https://react-hook-form.com/get-started#Applyvalidation */
 export const Input: WithForwardRefType = forwardRef((props, customRef) => {
-  const { placeholder, errors, attribute, label, register, isRequired, fieldType, dataAttributes} = props
+  const { placeholder, errors, attribute, label, register, isRequired, fieldType, dataAttributes, unit } = props
 
   const { ref, ...rest } = register(attribute,
     { required: isRequired ? "This is required" : undefined }
   );
 
+  const displayedUnit = (fieldType === 'currency' || unit) ? `(${fieldType === 'currency' ? '$' : unit || ''})` : '';
+
 
   return (
     <div className='input-wrapper'>
-      <label>{label}<span className='red'>{isRequired ? '*' : ''}</span>:</label>
+      <label>{label} {displayedUnit}<span className='red'>{isRequired ? '*' : ''}</span>:</label>
       <input
         {...rest}
         type={fieldType ? fieldType : 'text'}


### PR DESCRIPTION
# Description

This PR does two things:
  1. Adds a `unit` prop to `Input` component to tell users what the field units are
  2. Converts 'note' attributes from `Input` components to `TextArea` components