### PR TITLE
Add Message Telling Users Form Inputs Had Errors

### DIFF
--- a/application/react/AdhesiveCategory/AdhesiveCategoryForm/AdhesiveCategoryForm.tsx
+++ b/application/react/AdhesiveCategory/AdhesiveCategoryForm/AdhesiveCategoryForm.tsx
@@ -67,6 +67,9 @@ export const AdhesiveCategoryForm = () => {
               isRequired={true}
               errors={errors}
             />
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
+            
             <button className='create-entry submit-button' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>
         </div>

--- a/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
+++ b/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
@@ -68,6 +68,9 @@ export const CreditTermForm = () => {
               isRequired={true}
               errors={errors}
             />
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
+
             <button className='create-entry submit-button' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>
         </div>

--- a/application/react/Customer/CustomerForm/CustomerForm.tsx
+++ b/application/react/Customer/CustomerForm/CustomerForm.tsx
@@ -319,6 +319,9 @@ export const CustomerForm = () => {
               </div>
             </div>
             <button className='add-new-row' type="button" onClick={() => setShowContactForm(true)}><i className="fa-solid fa-plus"></i> Add Contact</button>
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
+
             <button className='btn-primary' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>
         </div>

--- a/application/react/Die/DieForm/DieForm.tsx
+++ b/application/react/Die/DieForm/DieForm.tsx
@@ -276,6 +276,9 @@ export const DieForm = () => {
               errors={errors}
               isRequired={true}
             />
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
+
             <div className='btn-wrapper'>
               <button className='create-entry submit-button' type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>

--- a/application/react/LinerType/LinerTypeForm/LinerTypeForm.tsx
+++ b/application/react/LinerType/LinerTypeForm/LinerTypeForm.tsx
@@ -67,6 +67,9 @@ export const LinerTypeForm = () => {
               isRequired={true}
               errors={errors}
             />
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
+
             <button className='create-entry submit-button' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>
         </div>

--- a/application/react/Material/MaterialForm/MaterialForm.tsx
+++ b/application/react/Material/MaterialForm/MaterialForm.tsx
@@ -381,7 +381,7 @@ export const MaterialForm = () => {
                   control={control}
                 />
               </div>
-
+              {/* Let user know some form inputs had errors */}
               <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
 
               <button className='create-entry submit-button' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>

--- a/application/react/MaterialCategory/MaterialCategoryForm/MaterialCategoryForm.tsx
+++ b/application/react/MaterialCategory/MaterialCategoryForm/MaterialCategoryForm.tsx
@@ -67,6 +67,9 @@ export const MaterialCategoryForm = () => {
               isRequired={true}
               errors={errors}
             />
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
+
             <button className='create-entry submit-button' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>
         </div>

--- a/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
+++ b/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
@@ -104,6 +104,9 @@ export const MaterialLengthAdjustmentForm = () => {
               isRequired={false}
               errors={errors}
             />
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
+
             <button className='create-entry submit-button' type="submit">{isUpdateRequest ? 'Update' : 'Create'} </button>
           </form>
         </div>

--- a/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
+++ b/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
@@ -226,6 +226,8 @@ export const MaterialOrderForm = () => {
                   fieldType='currency'
               />
             </div>
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
             <button className='create-entry submit-button' type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>
         </div>

--- a/application/react/Vendor/VendorForm/VendorForm.tsx
+++ b/application/react/Vendor/VendorForm/VendorForm.tsx
@@ -186,6 +186,8 @@ export const VendorForm = () => {
             />}
             </div>
             <button className='add-new-row' type="button" onClick={() => setShowAddressForm(true)}><i className="fa-solid fa-plus"></i> Add Address</button>
+            {/* Let user know some form inputs had errors */}
+            <p className='red'>{Object.keys(errors).length ? 'Some inputs had errors, please fix before attempting resubmission' : ''}</p>
 
             <button className='btn-primary' type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>


### PR DESCRIPTION
# Description

Previously, when submitting a form, there were cases when form inputs had errors when the user attempted to save the form.

Sometimes, if the form had many inputs, a user might not be able to see the input field's error message and might be confused why the form did not submit. 

This PR adds a message next to the submit button telling them that errors occurred above