### PR TITLE
Add Denormalized `lengthAdjustments` to DB attribute `material.inventory`

### DIFF
--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -89,7 +89,8 @@ export interface IMaterial extends SchemaTimestampsConfig, Document<MongooseId> 
     lengthArrived: number,
     lengthNotArrived: number,
     materialOrders: MongooseId[] | IMaterialOrder[],
-    manualLengthAdjustment: number
+    sumOfLengthAdjustments: number,
+    lengthAdjustments: MongooseId[] | IMaterialLengthAdjustment
   };
   netLength: number;
 }

--- a/application/api/models/material.ts
+++ b/application/api/models/material.ts
@@ -219,8 +219,12 @@ const schema = new Schema<IMaterial>({
       ref: 'MaterialOrder',
       type: [Schema.Types.ObjectId],
     },
-    manualLengthAdjustment: {
+    sumOfLengthAdjustments: {
       type: Number
+    },
+    lengthAdjustments: {
+      ref: 'MaterialLengthAdjustment',
+      type: [Schema.Types.ObjectId],
     }
   }
 }, {

--- a/application/api/services/materialInventoryService.ts
+++ b/application/api/services/materialInventoryService.ts
@@ -13,15 +13,6 @@ type MaterialLengthAdjustmentDetails = {
 /* 
   @See: 
     https://mongoplayground.net/
-  
-  @Returns: 
-    A map where the key is the material _id which maps to the net length of that material found in the MaterialLengthAdjustment db table
-  
-  @Notes:
-    type materialIdsWithTotalLengthAdjustments = {
-      _id: mongooseId,
-      totalLength: number
-    }
 */
 export async function getLengthAdjustmentDetailsByMaterialId(): Promise<Record<MongooseIdStr, MaterialLengthAdjustmentDetails>> {
   const materialIdsWithLengthAdjustmentDetails = await MaterialLengthAdjustmentModel.aggregate([

--- a/application/api/services/materialInventoryService.ts
+++ b/application/api/services/materialInventoryService.ts
@@ -75,7 +75,7 @@ export function getInventoryForMaterial(purchaseOrdersForMaterial: IMaterialOrde
   const sumOfLengthAdjustments = lengthAdjustmentDetails?.sum || 0
   const netLengthAvailable = lengthArrived + sumOfLengthAdjustments
 
-  const foo = {
+  return {
     netLengthAvailable: netLengthAvailable,
     lengthNotArrived: lengthNotArrived,
     lengthArrived: lengthArrived,
@@ -83,7 +83,6 @@ export function getInventoryForMaterial(purchaseOrdersForMaterial: IMaterialOrde
     sumOfLengthAdjustments: sumOfLengthAdjustments,
     lengthAdjustments: lengthAdjustmentDetails?.materialLengthAdjustmentIds || []
   }
-  return foo
 }
 
 export function buildMaterialInventory(material: IMaterial, allPurchaseOrdersForMaterial: IMaterialOrder[], netMaterialLengthAdjustment: number) {

--- a/application/react/Inventory/MaterialDetailsModal/MaterialDetailsModal.tsx
+++ b/application/react/Inventory/MaterialDetailsModal/MaterialDetailsModal.tsx
@@ -27,7 +27,7 @@ export const MaterialDetailsModal = (props: Props) => {
               </div>
             <div className='box box-two'>
             <h5>Adjustments:</h5> 
-              <span>{material.inventory.manualLengthAdjustment}</span>
+              <span>{material.inventory.sumOfLengthAdjustments}</span>
             </div>
             <div className='box box-three'>
               <h5>On Order:</h5>

--- a/application/react/Inventory/Materials/Material/MaterialCard.tsx
+++ b/application/react/Inventory/Materials/Material/MaterialCard.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import './MaterialCard.scss'
 import { observer } from 'mobx-react-lite';
-import { MaterialInventory } from '../../Inventory.tsx';
 import { Modal } from '../../../_global/Modal/Modal.tsx';
 import { Link, useNavigate } from 'react-router-dom';
 import { getDayMonthYear } from '../../../_helperFunctions/dateTime.ts';
@@ -10,6 +9,8 @@ import { useQuery } from '@tanstack/react-query';
 import { getMaterialOrdersByIds } from '../../../_queries/materialOrder.ts';
 import { LoadingIndicator } from '../../../_global/LoadingIndicator/LoadingIndicator.tsx';
 import { useErrorMessage } from '../../../_hooks/useErrorMessage.ts';
+import { BsPlusSlashMinus } from "react-icons/bs";
+
 
 function renderPurchaseOrders(material: IMaterial) {
   const navigate = useNavigate();
@@ -63,7 +64,8 @@ type Props = {
 const MaterialCard = observer((props: Props) => {
   const { material, onClick } = props;
   const [shouldShowPoModal, setShouldShowPoModal] = useState(false);
-  const numMaterialOrders = material.inventory.materialOrders?.length || 0;
+  const numMaterialOrders = material.inventory.materialOrders.length;
+  const numLengthAdjustments = material.inventory.lengthAdjustments.length
 
   const showPurchaseOrderModal = (e) => {
     if (e.currentTarget.classList.contains('disabled')) {
@@ -98,11 +100,17 @@ const MaterialCard = observer((props: Props) => {
               }
 
             </div>
-            <div className='material-option open-ticket-container tooltip-top enabled'>
-              <div className='icon-container' onClick={(e) => e.stopPropagation()}>
-                <i className="fa-regular fa-memo"></i>
+            <div className={`material-option open-ticket-container tooltip-top ${numLengthAdjustments === 0 ? 'disabled' : 'enabled'}`}>
+              <div className={`icon-container ${numLengthAdjustments === 0 && ''}`} onClick={(e) => e.stopPropagation()}>
+                <i><BsPlusSlashMinus /></i>
               </div>
-              <span className='tooltiptext'>View open tickets</span>
+              <span className='tooltiptext'>
+                {
+                  numLengthAdjustments === 0 ? 
+                    'No Adjustments' : 
+                    `View ${numLengthAdjustments} Adjustments`
+                }
+              </span>
             </div>
             <div className='material-option edit-container tooltip-top'>
               <Link to={`/react-ui/forms/material/${material._id}`} onClick={(e) => e.stopPropagation()}>
@@ -131,7 +139,7 @@ const MaterialCard = observer((props: Props) => {
         <div className='divide-line'></div>
         <div className='col col-right'>
           <span>Net</span>
-          <h2 className='material-length-ordered'>{material.inventory.lengthArrived + material.inventory.lengthNotArrived + material.inventory.manualLengthAdjustment}</h2>
+          <h2 className='material-length-ordered'>{material.inventory.netLengthAvailable}</h2>
         </div>
 
       </div>

--- a/application/react/stores/inventoryStore.ts
+++ b/application/react/stores/inventoryStore.ts
@@ -62,7 +62,7 @@ class InventoryStore implements Filter<any> {
   }
 
   getNetLengthAdjustments() {
-    return Object.values(this.materials).reduce((sum, material) => sum + (material.inventory.manualLengthAdjustment || 0), 0)
+    return Object.values(this.materials).reduce((sum, material) => sum + (material.inventory.sumOfLengthAdjustments || 0), 0)
   }
 
   getNetLengthOfMaterialsInInventory() {


### PR DESCRIPTION
# Description

Currently, we store two models `MaterialLengthAdjustment` and `Material`. A length adjustment relates to a via MaterialLengthAdjustment.material.

We need to regularly figure out how many materialLengthAdjustments relate to any given material. Instead of computing this frequently which will become increasingly expensive, I've decided to add a denormalized field: material.inventory.lengthAdjustments. This field is updated via mongoose hooks to provide quick, cheap, access to the materialLengthAdjustments a material has.