### PR TITLE
Inventory Page Modal Styling

### DIFF
--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -1,7 +1,7 @@
 import { Document } from "mongoose";
 import { SchemaTimestampsConfig } from "mongoose";
 import { IAddress, IContact, IShippingLocation } from "./schemas.ts";
-import { MongooseId } from "./typeAliases.ts";
+import { MongooseId, MongooseIdStr } from "./typeAliases.ts";
 import { AuthRoles } from "@shared/enums/auth.ts";
 
 export interface IDeliveryMethod extends SchemaTimestampsConfig, Document<MongooseId> {
@@ -88,9 +88,9 @@ export interface IMaterial extends SchemaTimestampsConfig, Document<MongooseId> 
     netLengthAvailable: number,
     lengthArrived: number,
     lengthNotArrived: number,
-    materialOrders: MongooseId[] | IMaterialOrder[],
+    materialOrders: MongooseIdStr[] | MongooseId[] | IMaterialOrder[],
     sumOfLengthAdjustments: number,
-    lengthAdjustments: MongooseId[] | IMaterialLengthAdjustment
+    lengthAdjustments: MongooseIdStr[] | MongooseId[] | IMaterialLengthAdjustment
   };
   netLength: number;
 }

--- a/application/api/controllers/materialLengthAdjustmentController.ts
+++ b/application/api/controllers/materialLengthAdjustmentController.ts
@@ -11,6 +11,27 @@ import { getSortOption } from '../services/mongooseService.ts';
 
 router.use(verifyBearerToken);
 
+router.post('/batch', async (request: Request, response: Response) => {
+  try {
+    const { ids } = request.body;
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return response.status(400).json({ error: "'ids' is invalid" });
+    }
+
+    const orders = await MaterialLengthAdjustmentModel
+      .find({ _id: { $in: ids } })
+      .populate('material')
+      .exec();
+
+    return response.json(orders)
+  } catch (error) {
+    console.error('Failed to fetch materialLengthAdjustments by ids', error);
+
+    return response.status(BAD_REQUEST).send(error.message);
+  }
+})
+
 router.post('/', async (request: Request, response: Response) => {
     try {
         const savedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.create(request.body);

--- a/application/react/Inventory/Materials/Material/MaterialCard.scss
+++ b/application/react/Inventory/Materials/Material/MaterialCard.scss
@@ -231,7 +231,7 @@
         }
       }
       .po-container.disabled, .open-ticket-container.disabled {
-        .po-counter, i {
+        .po-counter, .icon-container {
           &:hover {
             cursor: not-allowed;
           }

--- a/application/react/Inventory/Materials/Material/MaterialCard.scss
+++ b/application/react/Inventory/Materials/Material/MaterialCard.scss
@@ -278,6 +278,9 @@
   padding: 28px 32px 56px 32px;
   .title-wrapper {
     width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     h4 {
       color: rgb(87, 155, 252);
       margin-bottom: 0;
@@ -285,6 +288,13 @@
       display: flex;
       align-items: center;
       justify-content: center;
+    }
+    i {
+      &:hover {
+        color: #2F2B3D;
+        cursor: pointer;
+        background-color: rgba(var(--primary-dark-background), .12);
+    }
     }
   }
   .purchase-order-info-wrapper {
@@ -308,6 +318,7 @@
         flex-direction: row;
         border-radius: 5px;
         width: 100%;
+        cursor: pointer;
         .tb-cell {
           border: 1px solid #d0d4e4;
           margin-right: -1px;
@@ -355,6 +366,7 @@
         }
       }
       .tb-header {
+        cursor: default;
         .tb-cell {
           &:first-of-type {
             border-radius: 5px 0 0 0;

--- a/application/react/Inventory/Materials/Material/MaterialCard.scss
+++ b/application/react/Inventory/Materials/Material/MaterialCard.scss
@@ -277,21 +277,29 @@
   border-radius: 0.428rem;
   padding: 28px 32px 56px 32px;
   .title-wrapper {
-    display: flex;
-    justify-items: flex-start;
-    align-items: flex-end;
-    flex-direction: row;
+    width: 100%;
     h4 {
       color: rgb(87, 155, 252);
       margin-bottom: 0;
       margin-right: 15px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
   }
   .purchase-order-info-wrapper {
     max-height: 100%;
     overflow-y: auto;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+
     .po-table {
       margin-top: 15px;
+      width: 75%;
+
       .tb-header,
       .tb-row {
         display: flex;
@@ -299,6 +307,7 @@
         align-items: center;
         flex-direction: row;
         border-radius: 5px;
+        width: 100%;
         .tb-cell {
           border: 1px solid #d0d4e4;
           margin-right: -1px;
@@ -308,6 +317,20 @@
           align-items: center;
           height: 36px;
         }
+        .cell-50 {
+          width: 50%;
+          position: relative;
+          .pulse-indicator {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 7px;
+            height: 36px;
+            background-color: rgb(87, 155, 252);
+            margin-top: -1px;
+          }
+        }
+
         .cell-one {
           width: 30%;
           position: relative;

--- a/application/react/Inventory/Materials/Material/MaterialCard.tsx
+++ b/application/react/Inventory/Materials/Material/MaterialCard.tsx
@@ -143,7 +143,7 @@ const PurchaseOrderModal = (props: ModalProps) => {
           <h4>Purchase orders: {material.materialId}</h4>
           <i>
             <IoCreateOutline
-              title='Create new purchase order'
+              title='Create New Material Order'
               size={20}
               onClick={() => navigate('/react-ui/forms/material-order', {
                 state: {

--- a/application/react/Inventory/Materials/Material/MaterialCard.tsx
+++ b/application/react/Inventory/Materials/Material/MaterialCard.tsx
@@ -178,7 +178,7 @@ const LengthAdjustmentsModal = (props: ModalProps) => {
             <div className='tb-header'>
               <div className='tb-cell cell-50'>
                 <div className='pulse-indicator'></div>
-                Material ID
+                Material Name
               </div>
               <div className='tb-cell cell-50'>
                 Length

--- a/application/react/Inventory/Materials/Material/MaterialCard.tsx
+++ b/application/react/Inventory/Materials/Material/MaterialCard.tsx
@@ -12,6 +12,8 @@ import { useErrorMessage } from '../../../_hooks/useErrorMessage.ts';
 import { BsPlusSlashMinus } from "react-icons/bs";
 import { getMaterialLengthAdjustmentsByIds } from '../../../_queries/materialLengthAdjustment.ts';
 import { MongooseIdStr } from '@shared/types/typeAliases.ts';
+import { IoCreateOutline } from "react-icons/io5";
+import { MdOutlinePreview } from "react-icons/md";
 
 type Props = {
   material: IMaterial,
@@ -62,13 +64,13 @@ const MaterialCard = observer((props: Props) => {
               </div>
 
               {
-                shouldShowPoModal && 
-                <PurchaseOrderModal material={material} onClose={() => setShouldShowPoModal(!shouldShowPoModal)}/>
+                shouldShowPoModal &&
+                <PurchaseOrderModal material={material} onClose={() => setShouldShowPoModal(!shouldShowPoModal)} />
               }
 
               {
                 shouldShowLengthAdjustmentsModal &&
-                <LengthAdjustmentsModal material={material} onClose={() => setShouldShowLengthAdjustmentsModal(!shouldShowLengthAdjustmentsModal)}/>
+                <LengthAdjustmentsModal material={material} onClose={() => setShouldShowLengthAdjustmentsModal(!shouldShowLengthAdjustmentsModal)} />
               }
 
             </div>
@@ -78,8 +80,8 @@ const MaterialCard = observer((props: Props) => {
               </div>
               <span className='tooltiptext'>
                 {
-                  numLengthAdjustments === 0 ? 
-                    'No Adjustments' : 
+                  numLengthAdjustments === 0 ?
+                    'No Adjustments' :
                     `View ${numLengthAdjustments} Adjustments`
                 }
               </span>
@@ -126,18 +128,37 @@ const MaterialCard = observer((props: Props) => {
 });
 
 type ModalProps = {
-  material: IMaterial, 
+  material: IMaterial,
   onClose: () => void
 }
 
 const PurchaseOrderModal = (props: ModalProps) => {
   const { material, onClose } = props;
+  const navigate = useNavigate();
 
   return (
     <Modal onClose={() => onClose()}>
       <div className='modal-content'>
         <div className='title-wrapper'>
           <h4>Purchase orders: {material.materialId}</h4>
+          <i>
+            <IoCreateOutline
+              title='Create new purchase order'
+              size={20}
+              onClick={() => navigate('/react-ui/forms/material-order', {
+                state: {
+                  material: material._id
+                }
+              })}
+            />
+          </i>
+          <i>
+            <MdOutlinePreview
+              title='View All Material Orders'
+              size={20}
+              onClick={() => navigate('/react-ui/tables/material-order')}
+            />
+          </i>
         </div>
         <div className='purchase-order-info-wrapper'>
           <div className='po-table'>
@@ -166,12 +187,31 @@ const PurchaseOrderModal = (props: ModalProps) => {
 
 const LengthAdjustmentsModal = (props: ModalProps) => {
   const { material, onClose } = props;
+  const navigate = useNavigate();
 
   return (
     <Modal onClose={() => onClose()}>
       <div className='modal-content'>
         <div className='title-wrapper'>
           <h4>Material Length Adjustments: {material.materialId}</h4>
+          <i>
+            <IoCreateOutline
+              title='Create New Length Adjustment'
+              size={20}
+              onClick={() => navigate('/react-ui/forms/material-length-adjustment', {
+                state: {
+                  material: material._id
+                }
+              })}
+            />
+          </i>
+          <i>
+            <MdOutlinePreview
+              title='View All Length Adjustments'
+              size={20}
+              onClick={() => navigate('/react-ui/tables/material-length-adjustment')}
+            />
+          </i>
         </div>
         <div className='purchase-order-info-wrapper'>
           <div className='po-table'>
@@ -192,7 +232,7 @@ const LengthAdjustmentsModal = (props: ModalProps) => {
   )
 }
 
-function getLowInventoryClass({lowStockThreshold, lowStockBuffer, inventory}: IMaterial): string {
+function getLowInventoryClass({ lowStockThreshold, lowStockBuffer, inventory }: IMaterial): string {
   if (!lowStockThreshold || !lowStockBuffer) return 'low-inventory';
 
   if (inventory.netLengthAvailable < lowStockThreshold) {

--- a/application/react/Inventory/Materials/Material/MaterialCard.tsx
+++ b/application/react/Inventory/Materials/Material/MaterialCard.tsx
@@ -72,8 +72,8 @@ const MaterialCard = observer((props: Props) => {
               }
 
             </div>
-            <div className={`material-option open-ticket-container tooltip-top ${numLengthAdjustments === 0 ? 'disabled' : 'enabled'}`}>
-              <div className={`icon-container ${numLengthAdjustments === 0 && ''}`} onClick={(e) => showLengthAdjustmentsModal(e)}>
+            <div className={`material-option open-ticket-container tooltip-top ${numLengthAdjustments === 0 ? 'disabled' : 'enabled'}`} onClick={(e) => showLengthAdjustmentsModal(e)}>
+              <div className={`icon-container ${numLengthAdjustments === 0 && ''}`}>
                 <i><BsPlusSlashMinus /></i>
               </div>
               <span className='tooltiptext'>

--- a/application/react/Inventory/Materials/Material/MaterialCard.tsx
+++ b/application/react/Inventory/Materials/Material/MaterialCard.tsx
@@ -10,51 +10,8 @@ import { getMaterialOrdersByIds } from '../../../_queries/materialOrder.ts';
 import { LoadingIndicator } from '../../../_global/LoadingIndicator/LoadingIndicator.tsx';
 import { useErrorMessage } from '../../../_hooks/useErrorMessage.ts';
 import { BsPlusSlashMinus } from "react-icons/bs";
-
-
-function renderPurchaseOrders(material: IMaterial) {
-  const navigate = useNavigate();
-  const { isPending, isFetching, data: materialOrders, isError, error } = useQuery({
-    queryKey: ['get-material-orders', JSON.stringify(material.inventory.materialOrders)],
-    queryFn: async () => {
-      const materials = await getMaterialOrdersByIds(material.inventory.materialOrders);
-
-      return materials
-    },
-    initialData: []
-  })
-
-  if (isPending || isFetching) return (<LoadingIndicator />)
-
-  if (isError) {
-    useErrorMessage(error)
-  }
-
-  materialOrders.sort((a, b) => new Date(b.orderDate).getTime() - new Date(a.orderDate).getTime());
-
-  return (
-    materialOrders.map((mo, index: number) => (
-      <div className='tb-row' key={index} onClick={() => navigate(`/react-ui/forms/material-order/${mo._id}`)}>
-        <div className='tb-cell cell-one'>
-          <div className='pulse-indicator'></div>
-          {mo.purchaseOrderNumber}
-        </div>
-        <div className='tb-cell cell-two'>
-          <div className='pulse-indicator'></div>
-          {getDayMonthYear(mo.orderDate)}
-        </div>
-        <div className='tb-cell cell-three'>
-          <div className='pulse-indicator'></div>
-          {getDayMonthYear(mo.arrivalDate)}
-        </div>
-        <div className='tb-cell cell-four'>
-          <div className='pulse-indicator'></div>
-          {(mo.feetPerRoll * mo.totalRolls)}
-        </div>
-      </div>
-    ))
-  )
-}
+import { getMaterialLengthAdjustmentsByIds } from '../../../_queries/materialLengthAdjustment.ts';
+import { MongooseIdStr } from '@shared/types/typeAliases.ts';
 
 type Props = {
   material: IMaterial,
@@ -64,6 +21,7 @@ type Props = {
 const MaterialCard = observer((props: Props) => {
   const { material, onClick } = props;
   const [shouldShowPoModal, setShouldShowPoModal] = useState(false);
+  const [shouldShowLengthAdjustmentsModal, setShouldShowLengthAdjustmentsModal] = useState(false);
   const numMaterialOrders = material.inventory.materialOrders.length;
   const numLengthAdjustments = material.inventory.lengthAdjustments.length
 
@@ -73,6 +31,15 @@ const MaterialCard = observer((props: Props) => {
       return; // Prevent further execution if the class is present
     }
     setShouldShowPoModal(true)
+    e.stopPropagation() // This is required to prevent any parents' onClick from being called
+  };
+
+  const showLengthAdjustmentsModal = (e) => {
+    if (e.currentTarget.classList.contains('disabled')) {
+      e.stopPropagation();
+      return; // Prevent further execution if the class is present
+    }
+    setShouldShowLengthAdjustmentsModal(true)
     e.stopPropagation() // This is required to prevent any parents' onClick from being called
   };
 
@@ -99,9 +66,14 @@ const MaterialCard = observer((props: Props) => {
                 <PurchaseOrderModal material={material} onClose={() => setShouldShowPoModal(!shouldShowPoModal)}/>
               }
 
+              {
+                shouldShowLengthAdjustmentsModal &&
+                <LengthAdjustmentsModal material={material} onClose={() => setShouldShowLengthAdjustmentsModal(!shouldShowLengthAdjustmentsModal)}/>
+              }
+
             </div>
             <div className={`material-option open-ticket-container tooltip-top ${numLengthAdjustments === 0 ? 'disabled' : 'enabled'}`}>
-              <div className={`icon-container ${numLengthAdjustments === 0 && ''}`} onClick={(e) => e.stopPropagation()}>
+              <div className={`icon-container ${numLengthAdjustments === 0 && ''}`} onClick={(e) => showLengthAdjustmentsModal(e)}>
                 <i><BsPlusSlashMinus /></i>
               </div>
               <span className='tooltiptext'>
@@ -153,12 +125,12 @@ const MaterialCard = observer((props: Props) => {
   );
 });
 
-type PurchaseOrderModalProps = {
+type ModalProps = {
   material: IMaterial, 
   onClose: () => void
 }
 
-const PurchaseOrderModal = (props: PurchaseOrderModalProps) => {
+const PurchaseOrderModal = (props: ModalProps) => {
   const { material, onClose } = props;
 
   return (
@@ -192,6 +164,34 @@ const PurchaseOrderModal = (props: PurchaseOrderModalProps) => {
   )
 }
 
+const LengthAdjustmentsModal = (props: ModalProps) => {
+  const { material, onClose } = props;
+
+  return (
+    <Modal onClose={() => onClose()}>
+      <div className='modal-content'>
+        <div className='title-wrapper'>
+          <h4>Material Length Adjustments: {material.materialId}</h4>
+        </div>
+        <div className='purchase-order-info-wrapper'>
+          <div className='po-table'>
+            <div className='tb-header'>
+              <div className='tb-cell cell-50'>
+                <div className='pulse-indicator'></div>
+                Material ID
+              </div>
+              <div className='tb-cell cell-50'>
+                Length
+              </div>
+            </div>
+            {renderMaterialLengthAdjustments(material)}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
 function getLowInventoryClass({lowStockThreshold, lowStockBuffer, inventory}: IMaterial): string {
   if (!lowStockThreshold || !lowStockBuffer) return 'low-inventory';
 
@@ -204,6 +204,85 @@ function getLowInventoryClass({lowStockThreshold, lowStockBuffer, inventory}: IM
   }
 
   return '';
+}
+
+function renderPurchaseOrders(material: IMaterial) {
+  const navigate = useNavigate();
+  const { isPending, isFetching, data: materialOrders, isError, error } = useQuery({
+    queryKey: ['get-material-orders', JSON.stringify(material.inventory.materialOrders)],
+    queryFn: async () => {
+      const materials = await getMaterialOrdersByIds(material.inventory.materialOrders);
+
+      return materials
+    },
+    initialData: []
+  })
+
+  if (isPending || isFetching) return (<LoadingIndicator />)
+
+  if (isError) {
+    useErrorMessage(error)
+  }
+
+  materialOrders.sort((a, b) => new Date(b.orderDate).getTime() - new Date(a.orderDate).getTime());
+
+  return (
+    materialOrders.map((mo, index: number) => (
+      <div className='tb-row' key={index} onClick={() => navigate(`/react-ui/forms/material-order/${mo._id}`)}>
+        <div className='tb-cell cell-one'>
+          <div className='pulse-indicator'></div>
+          {mo.purchaseOrderNumber}
+        </div>
+        <div className='tb-cell cell-two'>
+          <div className='pulse-indicator'></div>
+          {getDayMonthYear(mo.orderDate)}
+        </div>
+        <div className='tb-cell cell-three'>
+          <div className='pulse-indicator'></div>
+          {getDayMonthYear(mo.arrivalDate)}
+        </div>
+        <div className='tb-cell cell-four'>
+          <div className='pulse-indicator'></div>
+          {(mo.feetPerRoll * mo.totalRolls)}
+        </div>
+      </div>
+    ))
+  )
+}
+
+function renderMaterialLengthAdjustments(material: IMaterial) {
+  const navigate = useNavigate();
+  const { isPending, isFetching, data: lengthAdjustments, isError, error } = useQuery({
+    queryKey: ['material-length-adjustments', JSON.stringify(material.inventory.lengthAdjustments)],
+    queryFn: async () => {
+      const lengthAdjustments = await getMaterialLengthAdjustmentsByIds(material.inventory.lengthAdjustments as MongooseIdStr[]);
+
+      return lengthAdjustments
+    },
+    initialData: []
+  })
+
+  if (isPending || isFetching) return (<LoadingIndicator />)
+
+  if (isError) {
+    useErrorMessage(error)
+  }
+
+  lengthAdjustments.sort((a, b) => new Date(b.updatedAt as string).getTime() - new Date(a.updatedAt as string).getTime());
+
+  return (
+    lengthAdjustments.map((lo, index: number) => (
+      <div className='tb-row' key={index} onClick={() => navigate(`/react-ui/forms/material-length-adjustment/${lo._id}`)}>
+        <div className='tb-cell cell-50'>
+          <div className='pulse-indicator'></div>
+          {(lo.material as IMaterial).name}
+        </div>
+        <div className='tb-cell cell-50'>
+          {lo.length}
+        </div>
+      </div>
+    ))
+  )
 }
 
 export default MaterialCard;

--- a/application/react/Inventory/Materials/MaterialCards.tsx
+++ b/application/react/Inventory/Materials/MaterialCards.tsx
@@ -28,7 +28,7 @@ const MaterialCards = observer(() => {
     inventoryStore.removeMaterial(materialMongooseId)
   })
 
-  const { isPending, isFetching } = useQuery({
+  const { isPending, isFetching } = useQuery<IMaterial[]>({
     queryKey: ['get-materials'],
     queryFn: async () => {
       const materials = await getMaterials();

--- a/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
+++ b/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import { useState } from 'react';
 import './MaterialLengthAdjustmentForm.scss';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useForm } from 'react-hook-form';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
@@ -15,11 +15,15 @@ import { useQuery } from '@tanstack/react-query';
 import { LoadingIndicator } from '../../_global/LoadingIndicator/LoadingIndicator.tsx';
 
 export const MaterialLengthAdjustmentForm = () => {
-  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<IMaterialLengthAdjustmentForm>();
   const navigate = useNavigate();
   const [materials, setMaterials] = useState<SelectOption[]>([])
   const { mongooseId } = useParams();
-
+  const { state } = useLocation();
+  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<IMaterialLengthAdjustmentForm>({
+    defaultValues: {
+      ...state || {}
+    }
+  });
   const isUpdateRequest: boolean = !!mongooseId && mongooseId.length > 0;
 
   const { isFetching: isFetchingFormToUpdate, isLoading: isLoadingFormToUpdate, error: fetchingFormError } = useQuery<IMaterialLengthAdjustmentForm>({

--- a/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
+++ b/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import './MaterialOrderForm.scss'
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import axios, { AxiosError, AxiosResponse } from 'axios';
@@ -21,10 +21,12 @@ import { useQuery } from '@tanstack/react-query';
 const materialOrderTableUrl = '/react-ui/tables/material-order'
 
 export const MaterialOrderForm = () => {
+  const { state } = useLocation();
   const { register, handleSubmit, formState: { errors }, reset, control } = useForm<IMaterialOrderForm>({
     defaultValues: {
       freightCharge: 0,
-      fuelCharge: 0
+      fuelCharge: 0,
+      ...state || {}
     }
   });
   const navigate = useNavigate();

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.scss
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.scss
@@ -14,6 +14,7 @@
   border-radius: 5px;
   height: 43px;
   overflow-x: hidden;
+  overflow-y: hidden;
 }
 
 .select-selected.active {

--- a/application/react/_global/Modal/Modal.scss
+++ b/application/react/_global/Modal/Modal.scss
@@ -5,7 +5,8 @@
   align-items: center;
   background-color: rgba(41,47,76,0.7);
   z-index: 99;
-  
+  cursor: default;
+
   top: 0;
   left: 0;
   width: 100%;

--- a/application/react/_queries/materialLengthAdjustment.ts
+++ b/application/react/_queries/materialLengthAdjustment.ts
@@ -1,0 +1,10 @@
+import { IMaterialLengthAdjustment } from "@shared/types/models";
+import { MongooseIdStr } from "@shared/types/typeAliases";
+import axios, { AxiosResponse } from "axios";
+
+export const getMaterialLengthAdjustmentsByIds = async (mongooseIds: MongooseIdStr[]): Promise<IMaterialLengthAdjustment[]> => {
+  const response : AxiosResponse = await axios.post(`/material-length-adjustments/batch`, { ids: mongooseIds });
+  const materialLengthAdjustments: IMaterialLengthAdjustment[] = response.data;
+
+  return materialLengthAdjustments
+}


### PR DESCRIPTION
# Description

This PR does work on the `MaterialOrder` and `MaterialLengthAdjustment` modals on the Inventory page.

Previously those modals were mostly placeholders, with minimal styling / functionality.

This PR restyles them and adds links for UX purposes