### PR TITLE
Huge Refactor to  Forms

### DIFF
--- a/application/api/controllers/materialCategoryController.ts
+++ b/application/api/controllers/materialCategoryController.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 const router = Router();
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { MaterialCategoryModel } from '../models/materialCategory.ts';
-import { BAD_REQUEST, SERVER_ERROR } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, SERVER_ERROR } from '../enums/httpStatusCodes.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { getSortOption } from '../services/mongooseService.ts';
@@ -87,7 +87,22 @@ router.get('/form/:id', async (request, response) => {
     console.log(error);
     request.flash('errors', [error.message]);
 
-    return response.status(SERVER_ERROR_CODE).redirect('back');
+    return response.status(SERVER_ERROR).redirect('back');
+  }
+});
+
+router.post('/', async (request, response) => {
+  try {
+      const materialCategory = await MaterialCategoryModel.create(request.body);
+
+      return response
+          .status(CREATED_SUCCESSFULLY)
+          .json(materialCategory);
+  } catch (error) {
+      console.error('Failed to create materialCategory: ', error);
+      return response
+          .status(SERVER_ERROR)
+          .send(error.message);
   }
 });
 
@@ -100,7 +115,7 @@ router.post('/form/:id', async (request, response) => {
     console.log(error);
     request.flash('errors', [error.message]);
 
-    return response.status(SERVER_ERROR_CODE).redirect('back');
+    return response.status(SERVER_ERROR).redirect('back');
   }
 });
 

--- a/application/react/Address/AddressForm/AddressForm.tsx
+++ b/application/react/Address/AddressForm/AddressForm.tsx
@@ -1,69 +1,61 @@
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import * as formStyles from '@ui/styles/form.module.scss'
 import * as sharedStyles from '@ui/styles/shared.module.scss'
+import { IAddressForm } from '@ui/types/forms';
 
 interface Props {
   onSubmit: (data: any) => void;
 }
 
-export const AddressForm = ({onSubmit}: Props) => {
-  const { register, handleSubmit, formState: { errors } } = useForm();
+export const AddressForm = ({ onSubmit }: Props) => {
+  const methods = useForm<IAddressForm>();
+  const { handleSubmit } = methods;
 
   return (
     <div>
-      <div className={formStyles.formCardHeader}>
-        <h3>New Address</h3>
-      </div>
-      <form onSubmit={handleSubmit(onSubmit)} className={formStyles.form}>
-        <div className={formStyles.formElementsWrapper}>
-          <div className={formStyles.inputGroupWrapper}>
-            <Input
-              attribute='name'
-              label="Name"
-              register={register}
-              isRequired={true}
-              errors={errors}
-            />
-            <Input
-              attribute='street'
-              label="Street"
-              register={register}
-              isRequired={true}
-              errors={errors}
-            />
-            <Input
-              attribute='unitOrSuite'
-              label="Unit or Suite #"
-              register={register}
-              isRequired={false}
-              errors={errors}
-            />
-            <Input
-              attribute='city'
-              label="City"
-              register={register}
-              isRequired={true}
-              errors={errors}
-            />
-            <Input
-              attribute='state'
-              label="State"
-              register={register}
-              isRequired={true}
-              errors={errors}
-            />
-            <Input
-              attribute='zipCode'
-              label="Zip"
-              register={register}
-              isRequired={true}
-              errors={errors}
-            />
-          </div>
-          <button className={sharedStyles.submitButton} type="submit">Submit</button>
+      <FormProvider {...methods}>
+        <div className={formStyles.formCardHeader}>
+          <h3>New Address</h3>
         </div>
-      </form>
+        <form onSubmit={handleSubmit(onSubmit)} className={formStyles.form}>
+          <div className={formStyles.formElementsWrapper}>
+            <div className={formStyles.inputGroupWrapper}>
+              <Input
+                attribute='name'
+                label="Name"
+                isRequired={true}
+              />
+              <Input
+                attribute='street'
+                label="Street"
+                isRequired={true}
+              />
+              <Input
+                attribute='unitOrSuite'
+                label="Unit or Suite #"
+                isRequired={false}
+              />
+              <Input
+                attribute='city'
+                label="City"
+                isRequired={true}
+              />
+              <Input
+                attribute='state'
+                label="State"
+                isRequired={true}
+              />
+              <Input
+                attribute='zipCode'
+                label="Zip"
+                isRequired={true}
+              />
+            </div>
+            <button className={sharedStyles.submitButton} type="submit">Submit</button>
+          </div>
+        </form>
+      </FormProvider>
     </div>
   )
 }

--- a/application/react/AdhesiveCategory/AdhesiveCategoryForm/AdhesiveCategoryForm.tsx
+++ b/application/react/AdhesiveCategory/AdhesiveCategoryForm/AdhesiveCategoryForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useNavigate, useParams } from "react-router-dom";
-import { useForm } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
@@ -15,7 +15,8 @@ const adhesiveCategoryTableUrl = '/react-ui/tables/adhesive-category'
 
 export const AdhesiveCategoryForm = () => {
   const { mongooseId } = useParams();
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<IAdhesiveCategoryForm>();
+  const methods = useForm<IAdhesiveCategoryForm>();
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -67,21 +68,21 @@ export const AdhesiveCategoryForm = () => {
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Adhesive Category</h3>
         </div>
         <div>
-          <form onSubmit={handleSubmit(onSubmit)} data-test='adhesive-category-form' className={formStyles.form}>
-            <div className={formStyles.formElementsWrapper}>
-              <div className={formStyles.inputGroupWrapper}>
-                <Input
-                  attribute='name'
-                  label="Name"
-                  register={register}
-                  isRequired={true}
-                  errors={errors}
-                />
-              </div>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)} data-test='adhesive-category-form' className={formStyles.form}>
+              <div className={formStyles.formElementsWrapper}>
+                <div className={formStyles.inputGroupWrapper}>
+                  <Input
+                    attribute='name'
+                    label="Name"
+                    isRequired={true}
+                  />
+                </div>
 
-              <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
-            </div>
-          </form>
+                <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
+              </div>
+            </form>
+          </FormProvider>
         </div>
       </div>
     </div>

--- a/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
+++ b/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useNavigate, useParams } from "react-router-dom";
 import { Input } from '../../_global/FormInputs/Input/Input';
@@ -15,7 +15,9 @@ const creditTermTableUrl = '/react-ui/tables/credit-term'
 
 export const CreditTermForm = () => {
   const { mongooseId } = useParams();
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<ICreditTermForm>();
+  // const { register, handleSubmit, formState: { errors }, reset } = useForm<ICreditTermForm>();
+  const methods = useForm<ICreditTermForm>();
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -67,21 +69,21 @@ export const CreditTermForm = () => {
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Credit Term</h3>
         </div>
         <div>
-          <form onSubmit={handleSubmit(onSubmit)} data-test='credit-term-form' className={formStyles.form}>
-            <div className={formStyles.formElementsWrapper}>
-              <div className={formStyles.inputGroupWrapper}>
-                <Input
-                  attribute='description'
-                  label="Description"
-                  register={register}
-                  isRequired={true}
-                  errors={errors}
-                />
-              </div>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)} data-test='credit-term-form' className={formStyles.form}>
+              <div className={formStyles.formElementsWrapper}>
+                <div className={formStyles.inputGroupWrapper}>
+                  <Input
+                    attribute='description'
+                    label="Description"
+                    isRequired={true}
+                  />
+                </div>
 
-              <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
-            </div>
-          </form>
+                <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
+              </div>
+            </form>
+          </FormProvider>
         </div>
       </div>
     </div>

--- a/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
+++ b/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
@@ -15,7 +15,6 @@ const creditTermTableUrl = '/react-ui/tables/credit-term'
 
 export const CreditTermForm = () => {
   const { mongooseId } = useParams();
-  // const { register, handleSubmit, formState: { errors }, reset } = useForm<ICreditTermForm>();
   const methods = useForm<ICreditTermForm>();
   const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();

--- a/application/react/Customer/Contact/ContactCard/ContactCard.tsx
+++ b/application/react/Customer/Contact/ContactCard/ContactCard.tsx
@@ -23,7 +23,7 @@ const ContactCard = (props: Props) => {
       <div className={styles.columnTd}>{contactStatus}</div>
       <div className={styles.columnTd}>{notes}</div>
       <div className={styles.columnTd}>{position}</div>
-      <div className={styles.columnTd}>{location.name}</div>
+      <div className={styles.columnTd}>{location?.name}</div>
       <div className={styles.columnTd}>
         <i><IoTrashOutline className={styles.deleteIcon} onClick={onDelete} /></i>
       </div>

--- a/application/react/Customer/Contact/ContactForm/ContactForm.tsx
+++ b/application/react/Customer/Contact/ContactForm/ContactForm.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { IContactForm, IAddressForm } from '@ui/types/forms';
 import { Input } from '../../../_global/FormInputs/Input/Input';
 import { IShippingLocationForm } from '@ui/types/forms';
@@ -19,6 +19,9 @@ export const ContactForm = (props: Props) => {
     locations
   } = props;
 
+  const methods = useForm<IContactForm>();
+  const { handleSubmit } = methods;
+
   const selectableLocations: SelectOption[] = locations.map((address: IAddressForm | IShippingLocationForm, index: number) => {
     return {
       displayName: `${address.name}: ${address.street}, ${address.city}, ${address.state}, ${address.zipCode}`,
@@ -26,80 +29,63 @@ export const ContactForm = (props: Props) => {
     }
   });
 
-  const { register, handleSubmit, formState: { errors }, control } = useForm<IContactForm>();
-
   return (
     <div>
       <div className={formStyles.formCardHeader}>
         <h3>New Business Contact</h3>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className={formStyles.form}>
-        <div className={formStyles.formElementsWrapper}>
-          <div className={formStyles.inputGroupWrapper}>
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)} className={formStyles.form}>
+          <div className={formStyles.formElementsWrapper}>
+            <div className={formStyles.inputGroupWrapper}>
             <Input
               attribute='fullName'
               label="Name"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
             <Input
               attribute='phoneNumber'
               label="Phone Number"
-              register={register}
               isRequired={false}
-              errors={errors}
             />
           </div>
           <div className={formStyles.inputGroupWrapper}>
             <Input
               attribute='phoneExtension'
               label="Phone Extension"
-              register={register}
               isRequired={false}
-              errors={errors}
             />
             <Input
               attribute='email'
               label="Email"
-              register={register}
               isRequired={false}
-              errors={errors}
             />
             <Input
               attribute='contactStatus'
               label="Contact Status"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
           </div>
           <TextArea
             attribute='notes'
             label="Notes"
-            register={register}
             isRequired={false}
-            errors={errors}
           />
           <Input
             attribute='position'
             label="Position"
-            register={register}
             isRequired={false}
-            errors={errors}
           />
           <CustomSelect
             attribute='location'
             label="Location"
             options={selectableLocations}
-            register={register}
             isRequired={false}
-            errors={errors}
-            control={control}
           />
           <button className={sharedStyles.submitButton} type="submit">Submit</button>
-        </div>
-      </form>
+          </div>
+        </form>
+      </FormProvider>
     </div>
   )
 }

--- a/application/react/Customer/CustomerForm/CustomerForm.tsx
+++ b/application/react/Customer/CustomerForm/CustomerForm.tsx
@@ -37,7 +37,7 @@ const customerTableUrl = '/react-ui/tables/customer'
 export const CustomerForm = () => {
   const { mongooseId } = useParams();
   const methods = useForm<ICustomerForm>();
-  const { handleSubmit, formState: { errors }, reset, control, register } = methods;
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -65,7 +65,7 @@ export const CustomerForm = () => {
   const preloadFormData = async () => {
     const creditTermSearchResults = await performTextSearch<ICreditTerm>('/credit-terms/search', { query: '', limit: '100' })
     const creditTerms = creditTermSearchResults.results
-
+  
     setCreditTerms(creditTerms.map((creditTerm: ICreditTerm) => (
       {
         displayName: creditTerm.description,
@@ -175,19 +175,16 @@ export const CustomerForm = () => {
                   attribute='customerId'
                   label="Customer ID"
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='name'
                   label="Name"
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='overun'
                   label="Overun"
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
               </div>
@@ -200,10 +197,7 @@ export const CustomerForm = () => {
                 attribute='creditTerms'
                 label="Credit Term"
                 options={creditTerms}
-                register={register}
                 isRequired={false}
-                errors={errors}
-                control={control}
               />
               <div className={styles.titleHeader}>
                 <h3>Business Locations:</h3>

--- a/application/react/Customer/CustomerForm/CustomerForm.tsx
+++ b/application/react/Customer/CustomerForm/CustomerForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { useForm } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import { ShippingLocationForm } from '../../ShippingLocation/ShippingLocationForm/ShippingLocationForm';
 import { IShippingLocationForm } from '@ui/types/forms';
 import { FormModal } from '../../_global/FormModal/FormModal';
@@ -36,7 +36,8 @@ const customerTableUrl = '/react-ui/tables/customer'
 
 export const CustomerForm = () => {
   const { mongooseId } = useParams();
-  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<ICustomerForm>();
+  const methods = useForm<ICustomerForm>();
+  const { handleSubmit, formState: { errors }, reset, control, register } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -166,27 +167,25 @@ export const CustomerForm = () => {
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Customer</h3>
         </div>
         <div>
-          <form onSubmit={handleSubmit(onCustomerFormSubmit)} data-test='customer-form' className={formStyles.form}>
-            <div className={formStyles.formElementsWrapper}>
-              <div className={formStyles.inputGroupWrapper}>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onCustomerFormSubmit)} data-test='customer-form' className={formStyles.form}>
+              <div className={formStyles.formElementsWrapper}>
+                <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='customerId'
                   label="Customer ID"
-                  register={register}
                   isRequired={true}
                   errors={errors}
                 />
                 <Input
                   attribute='name'
                   label="Name"
-                  register={register}
                   isRequired={true}
                   errors={errors}
                 />
                 <Input
                   attribute='overun'
                   label="Overun"
-                  register={register}
                   isRequired={true}
                   errors={errors}
                   leftUnit='@storm'
@@ -195,9 +194,7 @@ export const CustomerForm = () => {
               <TextArea
                 attribute='notes'
                 label="Notes"
-                register={register}
                 isRequired={false}
-                errors={errors}
               />
               <CustomSelect
                 attribute='creditTerms'
@@ -335,6 +332,7 @@ export const CustomerForm = () => {
               <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>
           </form>
+          </FormProvider>
         </div>
         {/* Code Below Renders a modal IFF user initiated one to open */}
         {

--- a/application/react/DeliveryMethod/DeliveryMethodForm/DeliveryMethodForm.tsx
+++ b/application/react/DeliveryMethod/DeliveryMethodForm/DeliveryMethodForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useNavigate, useParams } from "react-router-dom";
 import { Input } from '../../_global/FormInputs/Input/Input';
@@ -15,7 +15,8 @@ const deliveryMethodTableUrl = '/react-ui/tables/delivery-method'
 
 export const DeliveryMethodForm = () => {
   const { mongooseId } = useParams();
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<IDeliveryMethodForm>();
+  const methods = useForm<IDeliveryMethodForm>();
+  const { handleSubmit, reset } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -61,20 +62,20 @@ export const DeliveryMethodForm = () => {
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Delivery Method</h3>
         </div>
         <div>
-          <form onSubmit={handleSubmit(onSubmit)} data-test='delivery-method-form' className={formStyles.form}>
-            <div className={formStyles.formElementsWrapper}>
-              <div className={formStyles.inputGroupWrapper}>
-                <Input
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)} data-test='delivery-method-form' className={formStyles.form}>
+              <div className={formStyles.formElementsWrapper}>
+                <div className={formStyles.inputGroupWrapper}>
+                  <Input
                   attribute='name'
                   label="Name"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
               </div>
               <button className={sharedStyles.submitButton} type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
-            </div>
-          </form>
+              </div>
+            </form>
+          </FormProvider>
         </div>
       </div>
     </div>

--- a/application/react/Die/DieForm/DieForm.tsx
+++ b/application/react/Die/DieForm/DieForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Input } from '../../_global/FormInputs/Input/Input';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
@@ -24,12 +24,8 @@ export const DieForm = () => {
   const { mongooseId } = useParams();
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
 
-  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<IDieForm>({
-    defaultValues: {
-      quantity: 1,
-      isLamination: true
-    }
-  });
+  const methods = useForm<IDieForm>();
+  const { handleSubmit, formState: { errors }, reset } = methods;
 
   useEffect(() => {
     preloadFormData()
@@ -101,97 +97,73 @@ export const DieForm = () => {
         <div className={formStyles.formCardHeader}>
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Die</h3>
         </div>
-        <div>
+        <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)} data-test='die-form' className={formStyles.form}>
             <div className={formStyles.formElementsWrapper}>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='dieNumber'
                   label="Die Number"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                 />
                 <CustomSelect
                   attribute='shape'
                   label='Shape'
                   options={dieShapes.map((option) => ({ value: option, displayName: option }))}
-                  register={register}
-                  errors={errors}
                   isRequired={true}
-                  control={control}
                 />
                 <Input
                   attribute='quantity'
                   label="Quantity"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                 />
                 <CustomSelect
                   attribute='status'
                   label='Status'
                   options={dieStatuses.map((option) => ({ value: option, displayName: option }))}
-                  register={register}
-                  errors={errors}
                   isRequired={true}
-                  control={control}
                 />
               </div>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='sizeAcross'
                   label="Size Across"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='sizeAround'
                   label="Size Around"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='numberAcross'
                   label="Number Across"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='numberAround'
                   label="Number Around"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='cornerRadius'
                   label="Corner Radius"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='topAndBottom'
                   label="Across Matrix"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='leftAndRight'
                   label="Around Matrix"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   leftUnit='@storm'
                 />
@@ -200,47 +172,33 @@ export const DieForm = () => {
                 <Input
                   attribute='gear'
                   label="Gear"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                 />
                 <CustomSelect
                   attribute='toolType'
                   label='Tool Type'
                   options={toolTypes.map((option) => ({ value: option, displayName: option }))}
-                  register={register}
-                  errors={errors}
                   isRequired={true}
-                  control={control}
                 />
                 <CustomSelect
                   attribute='magCylinder'
                   label='Magnetic Cylinder'
                   options={dieMagCylinders.map((option) => ({ value: String(option), displayName: String(option) }))}
-                  register={register}
-                  errors={errors}
                   isRequired={true}
-                  control={control}
                 />
                 <Input
                   attribute='facestock'
                   label="Facestock"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                 />
                 <Input
                   attribute='liner'
                   label="Liner"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                 />
                 <Input
                   attribute='specialType'
                   label="Special Type"
-                  register={register}
-                  errors={errors}
                   isRequired={false}
                 />
               </div>
@@ -248,8 +206,6 @@ export const DieForm = () => {
                 <Input
                   attribute='cost'
                   label="Cost"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                   fieldType='currency'
                 />
@@ -257,39 +213,30 @@ export const DieForm = () => {
                   attribute='vendor'
                   label='Vendor'
                   options={dieVendors.map((option) => ({ value: option, displayName: option }))}
-                  register={register}
-                  errors={errors}
                   isRequired={true}
-                  control={control}
                 />
                 <Input
                   attribute='serialNumber'
                   label="Serial Number"
-                  register={register}
-                  errors={errors}
                   isRequired={true}
                 />
                 <Input
                   attribute='isLamination'
                   label="Lamination"
-                  register={register}
                   isRequired={false}
-                  errors={errors}
                   fieldType='checkbox'
                 />
               </div>
               <TextArea
                 attribute='notes'
                 label="Notes"
-                register={register}
-                errors={errors}
                 isRequired={true}
               />
 
               <button className={sharedStyles.submitButton} type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>
           </form>
-        </div>
+        </FormProvider>
       </div>
     </div>
   )

--- a/application/react/LinerType/LinerTypeForm/LinerTypeForm.tsx
+++ b/application/react/LinerType/LinerTypeForm/LinerTypeForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from "react-router-dom";
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { getOneLinerType } from '../../_queries/linerType';
@@ -15,7 +15,8 @@ const linerTypeTableUrl = '/react-ui/tables/liner-type'
 
 export const LinerTypeForm = () => {
   const { mongooseId } = useParams();
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<ILinerTypeForm>();
+  const methods = useForm<ILinerTypeForm>();
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -66,23 +67,21 @@ export const LinerTypeForm = () => {
         <div className={formStyles.formCardHeader}>
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Liner Type</h3>
         </div>
-        <div>
+        <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)} data-test='liner-type-form' className={formStyles.form}>
             <div className={formStyles.formElementsWrapper}>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='name'
                   label="Name"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
               </div>
 
               <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>
           </form>
-        </div>
+        </FormProvider>
       </div>
     </div>
   )

--- a/application/react/Material/MaterialForm/MaterialForm.tsx
+++ b/application/react/Material/MaterialForm/MaterialForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { AxiosError } from 'axios';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -21,7 +21,8 @@ const materialTableUrl = '/react-ui/tables/material'
 const locationRegex = /^[a-zA-Z][1-9][0-9]?$/;
 
 export const MaterialForm = () => {
-  const { register, handleSubmit, formState: { errors }, setError, reset, control } = useForm<IMaterialForm>();
+  const methods = useForm<IMaterialForm>();
+  const { handleSubmit, formState: { errors }, setError, reset } = methods;
   const navigate = useNavigate();
   const { mongooseId } = useParams();
   const axios = useAxios();
@@ -177,30 +178,24 @@ export const MaterialForm = () => {
         <div className={formStyles.formCardHeader}>
           <h3>{isUpdateRequest ? 'Edit' : 'Create'} Material</h3>
         </div>
-        <div>
+        <FormProvider {...methods}>
           <form id='material-form' className={formStyles.form} onSubmit={handleSubmit(onSubmit)} data-test='material-form'>
             <div className={formStyles.formElementsWrapper}>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='name'
                   label="Name"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='materialId'
                   label="Material ID"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='width'
                   label="Width"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                   rightUnit='@storm'
                 />
@@ -208,74 +203,55 @@ export const MaterialForm = () => {
                   attribute='vendor'
                   label="Vendor"
                   options={vendors}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
                 <Input
                   attribute='locationsAsStr'
                   label="Locations (comma-separated)"
-                  register={register}
                   isRequired={false}
-                  errors={errors}
                 />
               </div>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='thickness'
-                  label="Thickness"
-                  register={register}
+                  label="Thickness" 
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='weight'
                   label="Weight"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='faceColor'
                   label="Face Color"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='adhesive'
                   label="Adhesive"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
               </div>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='freightCostPerMsi'
                   label="Freight Cost (per MSI)"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='currency'
                 />
                 <Input
                   attribute='costPerMsi'
                   label="Cost (per MSI)"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='currency'
                 />
                 <Input
                   attribute='quotePricePerMsi'
                   label="Quote Price (Per MSI)"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='currency'
                 />
               </div>
@@ -283,17 +259,13 @@ export const MaterialForm = () => {
                 <Input
                   attribute='lowStockThreshold'
                   label="Low Stock Threshold"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='lowStockBuffer'
                   label="Low Stock Buffer"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
               </div>
@@ -301,116 +273,86 @@ export const MaterialForm = () => {
                 <Input
                   attribute='description'
                   label="Description"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
               </div>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='whenToUse'
                   label="When-to-use"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='alternativeStock'
                   label="Alternative Stock"
-                  register={register}
                   isRequired={false}
-                  errors={errors}
                 />
               </div>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='length'
                   label="Length"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='facesheetWeightPerMsi'
                   label="Facesheet Weight (Per MSI)"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='adhesiveWeightPerMsi'
                   label="Adhesive Weight (Per MSI)"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='linerWeightPerMsi'
                   label="Liner Weight (Per MSI)"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
                 <Input
                   attribute='productNumber'
                   label="Product Number"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='masterRollSize'
                   label="Master Roll Size"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
-                  unit={'mm'}
                 />
                 <Input
                   attribute='image'
                   label="Image"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <CustomSelect
                   attribute='linerType'
                   label="Liner Type"
                   options={linerTypes}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
                 <CustomSelect
                   attribute='adhesiveCategory'
                   label="Adhesive Category"
                   options={adhesiveCategories}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
                 <CustomSelect
                   attribute='materialCategory'
                   label="Material Category"
                   options={materialCategories}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
               </div>
 
               <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>
           </form>
-        </div>
+        </FormProvider>
       </div>
     </div>
   )

--- a/application/react/MaterialCategory/MaterialCategoryForm/MaterialCategoryForm.tsx
+++ b/application/react/MaterialCategory/MaterialCategoryForm/MaterialCategoryForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { IMaterialCategory } from '@shared/types/models';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
@@ -15,7 +15,8 @@ const materialCategoryTableUrl = '/react-ui/tables/material-category'
 
 export const MaterialCategoryForm = () => {
   const { mongooseId } = useParams();
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<IMaterialCategoryForm>();
+  const methods = useForm<IMaterialCategoryForm>();
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -66,23 +67,21 @@ export const MaterialCategoryForm = () => {
         <div className={formStyles.formCardHeader}>
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Material Category</h3>
         </div>
-        <div>
+        <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)} data-test='material-category-form' className={formStyles.form}>
             <div className={formStyles.formElementsWrapper}>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='name'
                   label="Name"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
               </div>
 
               <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>
           </form>
-        </div>
+        </FormProvider>
       </div>
     </div>
   )

--- a/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
+++ b/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentForm/MaterialLengthAdjustmentForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
@@ -20,11 +20,12 @@ export const MaterialLengthAdjustmentForm = () => {
   const [materials, setMaterials] = useState<SelectOption[]>([])
   const { mongooseId } = useParams();
   const { state } = useLocation();
-  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<IMaterialLengthAdjustmentForm>({
+  const methods = useForm<IMaterialLengthAdjustmentForm>({
     defaultValues: {
       ...state || {}
     }
   });
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const isUpdateRequest: boolean = !!mongooseId && mongooseId.length > 0;
 
   const { isFetching: isFetchingFormToUpdate, isLoading: isLoadingFormToUpdate, error: fetchingFormError } = useQuery<IMaterialLengthAdjustmentForm>({
@@ -95,7 +96,7 @@ export const MaterialLengthAdjustmentForm = () => {
         <div className={formStyles.formCardHeader}>
           <h3>Create Material Adjustment</h3>
         </div>
-        <div>
+        <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onFormSubmit)} data-test='material-length-adjustment-form' className={formStyles.form}>
             <div className={formStyles.formElementsWrapper}>
               <div className={formStyles.inputGroupWrapper}>
@@ -103,32 +104,25 @@ export const MaterialLengthAdjustmentForm = () => {
                   attribute='material'
                   label="Material"
                   options={materials}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
                 <Input
                   attribute='length'
                   label="Length"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='@storm'
                 />
               </div>
               <TextArea
                 attribute='notes'
                 label="Notes"
-                register={register}
                 isRequired={false}
-                errors={errors}
               />
 
               <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'} </button>
             </div>
           </form>
-        </div>
+        </FormProvider>
       </div>
     </div>
   )

--- a/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
+++ b/application/react/MaterialOrder/MaterialOrderForm/MaterialOrderForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { getUsers } from '../../_queries/users';
@@ -23,13 +23,14 @@ const materialOrderTableUrl = '/react-ui/tables/material-order'
 
 export const MaterialOrderForm = () => {
   const { state } = useLocation();
-  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<IMaterialOrderForm>({
+  const methods = useForm<IMaterialOrderForm>({
     defaultValues: {
       freightCharge: 0,
       fuelCharge: 0,
       ...state || {}
     }
   });
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();
   const { mongooseId } = useParams();
   const [users, setUsers] = useState<SelectOption[]>([])
@@ -147,7 +148,7 @@ export const MaterialOrderForm = () => {
         <div className={formStyles.formCardHeader}>
           <h3>Create Material Order</h3>
         </div>
-        <div>
+        <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onSubmit)} data-test='material-order-form' className={formStyles.form}>
             <div className={formStyles.formElementsWrapper}>
               <div className={formStyles.inputGroupWrapper}>
@@ -155,99 +156,72 @@ export const MaterialOrderForm = () => {
                   attribute='author'
                   label="Author"
                   options={users}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
                 <CustomSelect
                   attribute='material'
                   label="Material"
                   options={materials}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
                 <CustomSelect
                   attribute='vendor'
                   label="Vendors"
                   options={vendors}
-                  register={register}
                   isRequired={true}
-                  errors={errors}
-                  control={control}
                 />
               </div>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='purchaseOrderNumber'
                   label="Purchase Order Number"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='orderDate'
                   label="Order Date"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='date'
                 />
                 <Input
                   attribute='feetPerRoll'
                   label="Feet per Roll"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   leftUnit='ft / roll'
                 />
                 <Input
                   attribute='totalRolls'
                   label="Total Rolls"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='totalCost'
                   label="Total Cost"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='currency'
                 />
                 <Input
                   attribute='hasArrived'
                   label="Has Arrived"
-                  register={register}
                   isRequired={false}
-                  errors={errors}
                   fieldType='checkbox'
                 />
                 <Input
                   attribute='arrivalDate'
                   label="Arrival Date"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='date'
                 />
                 <Input
                   attribute='freightCharge'
                   label="Freight Charge"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='currency'
                 />
                 <Input
                   attribute='fuelCharge'
                   label="Fuel Charge"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                   fieldType='currency'
                 />
               </div>
@@ -255,15 +229,13 @@ export const MaterialOrderForm = () => {
                 attribute='notes'
                 label="Notes"
                 placeholder='Enter notes here...'
-                register={register}
                 isRequired={false}
-                errors={errors}
               />
 
               <button className={sharedStyles.submitButton} type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>
           </form>
-        </div>
+        </FormProvider>
       </div>
     </div>
   )

--- a/application/react/Navbars/Navbar/Navbar.tsx
+++ b/application/react/Navbars/Navbar/Navbar.tsx
@@ -23,6 +23,7 @@ const FORM_ITEMS: DropdownItem[] = [
   { path: '/react-ui/forms/adhesive-category', label: 'Adhesive Category' },
   { path: '/react-ui/forms/credit-term', label: 'Credit Term' },
   { path: '/react-ui/forms/customer', label: 'Customer' },
+  { path: '/react-ui/forms/delivery-method', label: 'Delivery Method' },
   { path: '/react-ui/forms/die', label: 'Die' },
   { path: '/react-ui/forms/liner-type', label: 'Liner Type' },
   { path: '/react-ui/forms/material', label: 'Material' },

--- a/application/react/Product/ProductForm/ProductForm.tsx
+++ b/application/react/Product/ProductForm/ProductForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { unwindDirections } from '../../../api/enums/unwindDirectionsEnum';
 import { ovOrEpmOptions } from '../../../api/enums/ovOrEpmEnum';
 import { defaultFinishType, finishTypes } from '../../../api/enums/finishTypesEnum';
@@ -33,7 +33,7 @@ export const ProductForm = () => {
   const [finishes, setFinishes] = useState<SelectOption[]>([])
   const [customers, setCustomers] = useState<SelectOption[]>([])
 
-  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<IProductForm>({
+  const methods = useForm<IProductForm>({
     defaultValues: {
       unwindDirection: defaultUnwindDirection,
       ovOrEpm: defaultOvOrEpm,
@@ -43,6 +43,7 @@ export const ProductForm = () => {
       spotPlate: false
     },
   });
+  const { handleSubmit, reset } = methods
 
   const preloadFormData = async () => {
     const diesSearchResults = await performTextSearch<IDie>('/dies/search', { limit: '100', });
@@ -117,149 +118,111 @@ export const ProductForm = () => {
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Product</h3>
         </div>
         <div>
-          <form onSubmit={handleSubmit(onSubmit)} data-test='product-form' className={formStyles.form}>
-            <div className={formStyles.formElementsWrapper}>
-              <div className={formStyles.inputGroupWrapper}>
-                <CustomSelect
-                  attribute='customer'
-                  label="Customer"
-                  options={customers}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                  isRequired={true}
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)} data-test='product-form' className={formStyles.form}>
+              <div className={formStyles.formElementsWrapper}>
+                <div className={formStyles.inputGroupWrapper}>
+                  <CustomSelect
+                    attribute='customer'
+                    label="Customer"
+                    options={customers}
+                    isRequired={true}
+                  />
+                  <Input
+                    attribute='productDescription'
+                    label="Product Description"
+                    isRequired={true}
+                  />
+                </div>
+                <div className={formStyles.inputGroupWrapper}>
+                  <CustomSelect
+                    attribute='unwindDirection'
+                    label='Unwind Direction'
+                    options={unwindDirections.map((direction) => ({ value: String(direction), displayName: String(direction) }))}
+                    isRequired={true}
+                  />
+                  <CustomSelect
+                    attribute='ovOrEpm'
+                    label='OV / EPM'
+                    options={ovOrEpmOptions.map((option) => ({ value: option, displayName: option }))}
+                    isRequired={true}
+                  />
+                  <CustomSelect
+                    attribute='finishType'
+                    label='Finish Types'
+                    options={finishTypes.map((finishType) => ({ value: finishType, displayName: finishType }))}
+                    isRequired={true}
+                  />
+                </div>
+                <div className={formStyles.inputGroupWrapper}>
+                  <CustomSelect
+                    attribute='die'
+                    label="Die"
+                    options={dies}
+                    isRequired={true}
+                  />
+                  <CustomSelect
+                    attribute='primaryMaterial'
+                    label="Primary Material"
+                    options={materials}
+                    isRequired={true}
+                  />
+                  <CustomSelect
+                    attribute='secondaryMaterial'
+                    label="Secondary Material"
+                    options={materials}
+                    isRequired={true}
+                  />
+                  <CustomSelect
+                    attribute='finish'
+                    label="Finish"
+                    options={finishes}
+                    isRequired={true}
+                  />
+                </div>
+                <div className={formStyles.inputGroupWrapper}>
+                  <Input
+                    attribute='coreDiameter'
+                    label="Core Diameter"
+                    isRequired={true}
+                  />
+                  <Input
+                    attribute='labelsPerRoll'
+                    label="Labels Per Roll"
+                    isRequired={true}
+                  />
+                  <Input
+                    attribute='overun'
+                    label="Overun"
+                    isRequired={true}
+                  />
+                  <Input
+                    attribute='numberOfColors'
+                    label="Number of Colors"
+                    isRequired={true}
+                  />
+                  <Input
+                    attribute='spotPlate'
+                    label="Has Spot Plate"
+                    fieldType='checkbox'
+                  />
+                </div>
+                <TextArea
+                  attribute='artNotes'
+                  label="Art Notes"
                 />
-                <Input
-                  attribute='productDescription'
-                  label="Product Description"
-                  register={register}
-                  errors={errors}
-                  isRequired={true}
+                <TextArea
+                  attribute='pressNotes'
+                  label="Press Notes"
                 />
+                <TextArea
+                  attribute='dieCuttingNotes'
+                  label="Die Cutting Notes"
+                />
+                <button className={sharedStyles.submitButton} type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
               </div>
-              <div className={formStyles.inputGroupWrapper}>
-                <CustomSelect
-                  attribute='unwindDirection'
-                  label='Unwind Direction'
-                  options={unwindDirections.map((direction) => ({ value: String(direction), displayName: String(direction) }))}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                  isRequired={true}
-                />
-                <CustomSelect
-                  attribute='ovOrEpm'
-                  label='OV / EPM'
-                  options={ovOrEpmOptions.map((option) => ({ value: option, displayName: option }))}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                  isRequired={true}
-                />
-                <CustomSelect
-                  attribute='finishType'
-                  label='Finish Types'
-                  options={finishTypes.map((finishType) => ({ value: finishType, displayName: finishType }))}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                  isRequired={true}
-                />
-              </div>
-              <div className={formStyles.inputGroupWrapper}>
-                <CustomSelect
-                  attribute='die'
-                  label="Die"
-                  options={dies}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                  isRequired={true}
-                />
-                <CustomSelect
-                  attribute='primaryMaterial'
-                  label="Primary Material"
-                  options={materials}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                  isRequired={true}
-                />
-                <CustomSelect
-                  attribute='secondaryMaterial'
-                  label="Secondary Material"
-                  options={materials}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                />
-                <CustomSelect
-                  attribute='finish'
-                  label="Finish"
-                  options={finishes}
-                  register={register}
-                  errors={errors}
-                  control={control}
-                />
-              </div>
-              <div className={formStyles.inputGroupWrapper}>
-                <Input
-                  attribute='coreDiameter'
-                  label="Core Diameter"
-                  register={register}
-                  errors={errors}
-                  isRequired={true}
-                />
-                <Input
-                  attribute='labelsPerRoll'
-                  label="Labels Per Roll"
-                  register={register}
-                  errors={errors}
-                  isRequired={true}
-                />
-                <Input
-                  attribute='overun'
-                  label="Overun"
-                  register={register}
-                  errors={errors}
-                />
-                <Input
-                  attribute='numberOfColors'
-                  label="Number of Colors"
-                  register={register}
-                  errors={errors}
-                  isRequired={true}
-                />
-                <Input
-                  attribute='spotPlate'
-                  label="Has Spot Plate"
-                  register={register}
-                  errors={errors}
-                  fieldType='checkbox'
-                />
-              </div>
-              <TextArea
-                attribute='artNotes'
-                label="Art Notes"
-                register={register}
-                errors={errors}
-              />
-              <TextArea
-                attribute='pressNotes'
-                label="Press Notes"
-                register={register}
-                errors={errors}
-              />
-              <TextArea
-                attribute='dieCuttingNotes'
-                label="Die Cutting Notes"
-                register={register}
-                errors={errors}
-              />
-
-              <button className={sharedStyles.submitButton} type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
-            </div>
-          </form>
+            </form>
+          </FormProvider>
         </div>
       </div>
     </div>

--- a/application/react/ShippingLocation/ShippingLocationCard/ShippingLocationCard.tsx
+++ b/application/react/ShippingLocation/ShippingLocationCard/ShippingLocationCard.tsx
@@ -1,9 +1,16 @@
+import { IShippingLocationForm } from '@ui/types/forms';
 import * as styles from './ShippingLocationCard.module.scss'
 import { IoTrashOutline } from 'react-icons/io5';
 
-const ShippingLocationCard = (props) => {
+type Props = {
+  data: IShippingLocationForm,
+  onDelete: () => void
+}
+
+const ShippingLocationCard = (props: Props) => {
   const { data, onDelete } = props;
   const { freightAccountNumber, deliveryMethod, name, street, unitOrSuite, city, state, zipCode } = data;
+
   return (
     <div className={styles.shippingLocationCard}>
       <div className={styles.columnTd}>{freightAccountNumber}</div>

--- a/application/react/ShippingLocation/ShippingLocationForm/ShippingLocationForm.tsx
+++ b/application/react/ShippingLocation/ShippingLocationForm/ShippingLocationForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
 import { IShippingLocationForm } from '@ui/types/forms.ts';
@@ -17,6 +17,9 @@ export const ShippingLocationForm = (props: Props) => {
   const {
     onSubmit,
   } = props;
+
+  const methods = useForm<IShippingLocationForm>();
+  const { handleSubmit } = methods;
 
   const [deliveryMethods, setDeliveryMethods] = useState<SelectOption[]>([]);
 
@@ -35,78 +38,61 @@ export const ShippingLocationForm = (props: Props) => {
       .catch((error: AxiosError) => useErrorMessage(error))
   }, [])
 
-  const { register, handleSubmit, formState: { errors }, control } = useForm<IShippingLocationForm>();
-
   return (
     <div>
       <div className={formStyles.formCardHeader}>
         <h3>New Shipping Address</h3>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className={formStyles.form}>
-        <div className={formStyles.formElementsWrapper}>
-          <div className={formStyles.inputGroupWrapper}>
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)} className={formStyles.form}>
+          <div className={formStyles.formElementsWrapper}>
+            <div className={formStyles.inputGroupWrapper}>
             <Input
               attribute='name'
               label="Name"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
             <Input
               attribute='freightAccountNumber'
               label="Freight Account Number"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
             <CustomSelect
               attribute='deliveryMethod'
               label="Delivery Method"
               options={deliveryMethods}
-              register={register}
               isRequired={false}
-              errors={errors}
-              control={control}
             />
             <Input
               attribute='street'
               label="Street"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
             <Input
               attribute='unitOrSuite'
               label="Unit or Suite #"
-              register={register}
               isRequired={false}
-              errors={errors}
             />
             <Input
               attribute='city'
               label="City"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
             <Input
               attribute='state'
               label="State"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
             <Input
               attribute='zipCode'
               label="Zip"
-              register={register}
               isRequired={true}
-              errors={errors}
             />
           </div>
           <button className={sharedStyles.submitButton} type="submit">Submit</button>
-        </div>
-      </form>
+          </div>
+        </form>
+      </FormProvider>
     </div>
   )
 }

--- a/application/react/User/Profile/Profile.tsx
+++ b/application/react/User/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { Input } from '../../_global/FormInputs/Input/Input';
@@ -17,7 +17,8 @@ export const Profile = () => {
   const queryClient = useQueryClient()
   const { user: loggedInUser, isLoading: isLoadingUser, isFetching: isFetchingUser, error } = useLoggedInUser();
 
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<IUserForm>();
+  const methods = useForm<IUserForm>();
+  const { handleSubmit, reset } = methods;
 
   useEffect(() => {
     reset({
@@ -59,51 +60,42 @@ export const Profile = () => {
       <div className={sharedStyles.card}>
         {
           (isLoadingUser || isFetchingUser) ? <LoadingIndicator /> : (
-            <form onSubmit={handleSubmit(onSubmit)} data-test='user-form'>
-              <Input
-                attribute='email'
-                label="Email"
-                isRequired
-                register={register}
-                errors={errors}
-              />
-              <Input
-                attribute='firstName'
-                label="First Name"
-                isRequired
-                register={register}
-                errors={errors}
-              />
-              <Input
-                attribute='lastName'
-                label="Last Name"
-                isRequired
-                register={register}
-                errors={errors}
-              />
-              <Input
-                attribute='jobRole'
-                label="Job Role"
-                register={register}
-                errors={errors}
-              />
-              <Input
-                attribute='birthDate'
-                fieldType='date'
-                isRequired
-                label="Birth Date"
-                register={register}
-                errors={errors}
-              />
-              <Input
-                attribute='phoneNumber'
-                label="Phone"
-                register={register}
-                errors={errors}
-              />
-              <button className={sharedStyles.submitButton} type='submit'>{'Update'}</button>
-            </form>
-          )}
+            <FormProvider {...methods}>
+              <form onSubmit={handleSubmit(onSubmit)} data-test='user-form'>
+                <Input
+                  attribute='email'
+                  label="Email"
+                  isRequired
+                />
+                <Input
+                  attribute='firstName'
+                  label="First Name"
+                  isRequired
+                />
+                <Input
+                  attribute='lastName'
+                  label="Last Name"
+                  isRequired
+                />
+                <Input
+                  attribute='jobRole'
+                  label="Job Role"
+                />
+                <Input
+                  attribute='birthDate'
+                  fieldType='date'
+                  isRequired
+                  label="Birth Date"
+                />
+                <Input
+                  attribute='phoneNumber'
+                  label="Phone"
+                />
+                <button className={sharedStyles.submitButton} type='submit'>{'Update'}</button>
+              </form>
+            </FormProvider>
+          )
+        }
       </div>
 
 

--- a/application/react/Vendor/VendorForm/VendorForm.tsx
+++ b/application/react/Vendor/VendorForm/VendorForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
@@ -15,7 +15,8 @@ const vendorTableUrl = '/react-ui/tables/vendor'
 
 export const VendorForm = () => {
   const { mongooseId } = useParams();
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<IVendorForm>();
+  const methods = useForm<IVendorForm>();
+  const { handleSubmit, formState: { errors }, reset } = methods;
   const navigate = useNavigate();
 
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
@@ -88,109 +89,82 @@ export const VendorForm = () => {
         <div className={formStyles.formCardHeader}>
           <h3>{isUpdateRequest ? 'Update' : 'Create'} Vendor</h3>
         </div>
-        <div>
+        <FormProvider {...methods}>
           <form onSubmit={handleSubmit(onVendorFormSubmit)} data-test='vendor-form' className={formStyles.form}>
             <div className={formStyles.formElementsWrapper}>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='name'
                   label="Name"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='phoneNumber'
                   label="Phone #"
-                  register={register}
                   isRequired={false}
-                  errors={errors}
                 />
                 <Input
                   attribute='email'
                   label="Email"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='website'
                   label="Website"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
               </div>
               <div className={formStyles.inputGroupWrapper}>
                 <Input
                   attribute='primaryContactName'
                   label="P.C Name"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='primaryContactPhoneNumber'
                   label="P.C Phone #"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='primaryContactEmail'
                   label="P.C Email"
-                  register={register}
                   isRequired={true}
-                  errors={errors}
                 />
                 <Input
                   attribute='mfgSpecNumber'
                   label="MFG Spec #"
-                  register={register}
                   isRequired={false}
-                  errors={errors}
                 />
               </div>
               <TextArea
                 attribute='notes'
                 label="Notes"
-                register={register}
                 isRequired={false}
-                errors={errors}
               />
 
               <div className={formStyles.inputGroupWrapper}>
-              <Input
-                  attribute='remittanceAddress'
-                  label="Remittance same as Primary Address?"
-                  register={register}
-                  isRequired={false}
-                  errors={errors}
-                  fieldType='checkbox'
-                  defaultChecked={true}
-                />
-                {/* <label>
+                <label>
                   <input
                     type="checkbox"
                     checked={isPrimaryAddressSameAsRemittance}
                     onChange={(e) => setIsPrimaryAddressSameAsRemittance(e.target.checked)}
                   />
                   Remittance same as Primary Address?
-                </label> */}
+                </label>
               </div>
 
               {/* Primary Address Input Fields */}
-              <AddressFormAttributes label='Primary Address' attribute='primaryAddress' register={register} errors={errors} />
+              <AddressFormAttributes label='Primary Address' attribute='primaryAddress' />
               {/* Remittance Address Input Fields */}
               {!isPrimaryAddressSameAsRemittance && (
-                <AddressFormAttributes label='Remittance Address' attribute='remittanceAddress' register={register} errors={errors} />
+                <AddressFormAttributes label='Remittance Address' attribute='remittanceAddress' />
               )
               }
 
               <button className={sharedStyles.submitButton} type="submit">{isUpdateRequest ? 'Update' : 'Create'}</button>
             </div>
           </form>
-        </div>
+        </FormProvider>
       </div>
     </div>
   );
@@ -199,12 +173,10 @@ export const VendorForm = () => {
 interface AddressProps {
   attribute: string;
   label: string;
-  register: any;
-  errors: any
 }
 
 const AddressFormAttributes = (props: AddressProps) => {
-  const { attribute, register, errors, label } = props;
+  const { attribute, label } = props;
 
   return (
     <div>
@@ -215,44 +187,32 @@ const AddressFormAttributes = (props: AddressProps) => {
         <Input
           attribute={`${attribute}.name`}
           label="Name"
-          register={register}
           isRequired={true}
-          errors={errors}
         />
         <Input
           attribute={`${attribute}.street`}
           label="Street"
-          register={register}
           isRequired={true}
-          errors={errors}
         />
         <Input
           attribute={`${attribute}.unitOrSuite`}
           label="Unit or Suite #"
-          register={register}
           isRequired={false}
-          errors={errors}
         />
         <Input
           attribute={`${attribute}.city`}
           label="City"
-          register={register}
           isRequired={true}
-          errors={errors}
         />
         <Input
           attribute={`${attribute}.state`}
           label="State"
-          register={register}
           isRequired={true}
-          errors={errors}
         />
         <Input
           attribute={`${attribute}.zipCode`}
           label="Zip"
-          register={register}
           isRequired={true}
-          errors={errors}
         />
       </div>
     </div>

--- a/application/react/_auth/ChangePassword/ChangePassword.tsx
+++ b/application/react/_auth/ChangePassword/ChangePassword.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Input } from '../../_global/FormInputs/Input/Input';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
@@ -9,7 +9,8 @@ import * as sharedStyles from '@ui/styles/shared.module.scss';
 
 export const ChangePassword = () => {
   const newPasswordFieldRef = useRef<HTMLInputElement>(null);
-  const { register, handleSubmit, formState: { errors }, reset } = useForm();
+  const methods = useForm();
+  const { handleSubmit } = methods;
   const { mongooseId, token } = useParams();
   const navigate = useNavigate();
 
@@ -27,33 +28,31 @@ export const ChangePassword = () => {
   }
 
   return (
-    <form id='change-password-form' onSubmit={ handleSubmit(onSubmit) }>
-    <Input
-        attribute='password'
-        label="New Password"
-        register={register}
-        isRequired={true}
-        errors={errors}
-        ref={newPasswordFieldRef}
-        fieldType='password'
-        dataAttributes={
-          {'data-test': 'password-input'}
-        }
-    />
-    <Input
-        attribute='repeatPassword'
-        label="Re-type Password"
-        register={register}
-        isRequired={true}
-        errors={errors}
-        ref={newPasswordFieldRef}
-        fieldType='password'
-        dataAttributes={
-          {'data-test': 'repeat-password-input'}
-        }
-    />
-    <button className={sharedStyles.submitButton} type='submit' data-test='change-password-btn'>Save Password</button>
-  </form>
+    <FormProvider {...methods}>
+      <form id='change-password-form' onSubmit={handleSubmit(onSubmit)}>
+        <Input
+          attribute='password'
+          label="New Password"
+          isRequired={true}
+          ref={newPasswordFieldRef}
+          fieldType='password'
+          dataAttributes={
+            { 'data-test': 'password-input' }
+          }
+        />
+        <Input
+          attribute='repeatPassword'
+          label="Re-type Password"
+          isRequired={true}
+          ref={newPasswordFieldRef}
+          fieldType='password'
+          dataAttributes={
+            { 'data-test': 'repeat-password-input' }
+          }
+        />
+        <button className={sharedStyles.submitButton} type='submit' data-test='change-password-btn'>Save Password</button>
+      </form>
+    </FormProvider>
   )
 }
 

--- a/application/react/_auth/ForgotPassword/ForgotPassword.tsx
+++ b/application/react/_auth/ForgotPassword/ForgotPassword.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
@@ -10,7 +10,8 @@ import * as styles from './ForgotPassword.module.scss'
 
 export const ForgotPassword = () => {
   const resetPasswordFieldRef = useRef<HTMLInputElement>(null);
-  const { register, handleSubmit, formState: { errors }, reset } = useForm();
+  const methods = useForm();
+  const { handleSubmit } = methods;
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -39,20 +40,20 @@ export const ForgotPassword = () => {
               <h4>Forgot Password? 🔒</h4>
               <p>Enter your email and we'll send you instructions to reset your password.</p>
             </div>
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <Input
-                attribute='email'
-                label="Email"
-                register={register}
-                isRequired={true}
-                errors={errors}
-                ref={resetPasswordFieldRef}
-                dataAttributes={
-                  { 'data-test': 'email-input' }
-                }
-              />
-              <button className={sharedStyles.submitButton} type='submit' data-test='reset-password-btn'>Reset</button>
-            </form>
+            <FormProvider {...methods}>
+              <form onSubmit={handleSubmit(onSubmit)}>
+                <Input
+                  attribute='email'
+                  label="Email"
+                  isRequired={true}
+                  ref={resetPasswordFieldRef}
+                  dataAttributes={
+                    { 'data-test': 'email-input' }
+                  }
+                />
+                <button className={sharedStyles.submitButton} type='submit' data-test='reset-password-btn'>Reset</button>
+              </form>
+            </FormProvider>
             <div>
               <a href='/react-ui/login'>Back to login</a>
             </div>

--- a/application/react/_auth/Login/Login.tsx
+++ b/application/react/_auth/Login/Login.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useAuth } from '../../_hooks/useAuth';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Input } from '../../_global/FormInputs/Input/Input';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import axios from 'axios';
 import { AxiosError, AxiosResponse } from 'axios';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
@@ -21,7 +21,8 @@ export const Login = () => {
 
   const userRef = useRef<HTMLInputElement>(null);
 
-  const { register, handleSubmit, formState: { errors }, reset } = useForm();
+  const methods = useForm();
+  const { handleSubmit } = methods;
 
   const handlePasswordIconClicked = () => {
     setShowPassword(!showPassword);
@@ -135,14 +136,13 @@ export const Login = () => {
                 <h4>Welcome to ELI.</h4>
                 <p>Please sign in below.</p>
               </div>
-              <form className={styles.loginForm} onSubmit={handleSubmit(onSubmit)}>
+              <FormProvider {...methods}>
+                <form className={styles.loginForm} onSubmit={handleSubmit(onSubmit)}>
                   <div className={styles.inputWrapper}>
                     <Input
                         attribute='email'
                         label="Email"
-                        register={register}
                         isRequired={true}
-                        errors={errors}
                         ref={userRef}
                         dataAttributes={
                           {'data-test': 'username-input'}
@@ -153,14 +153,11 @@ export const Login = () => {
                     <Input
                         attribute='password'
                         label="Password"
-                        register={register}
                         isRequired={true}
-                        errors={errors}
                         fieldType={showPassword ? 'text' : 'password'}
                         dataAttributes={
                           {'data-test': 'password-input'}
                         }
-                        //rightUnit='mm'
                         RightIcon={<PasswordIcon showPassword={showPassword} onClick={handlePasswordIconClicked} />}
                     />
                   </div>
@@ -180,6 +177,7 @@ export const Login = () => {
                   Don't have an account?
                   <Link to='/react-ui/register'>Create Account</Link>
                 </div>
+              </FormProvider>
             </div>
 
           </div>

--- a/application/react/_auth/Register/Register.tsx
+++ b/application/react/_auth/Register/Register.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Input } from '../../_global/FormInputs/Input/Input';
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import { Link, useNavigate } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
 import * as sharedStyles from '../../_styles/shared.module.scss';
@@ -12,7 +12,8 @@ export const Register = () => {
   const emailFieldRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
 
-  const { register, handleSubmit, formState: { errors }, reset } = useForm();
+  const methods = useForm();
+  const { handleSubmit } = methods;
 
   useEffect(() => {
     emailFieldRef.current?.focus();
@@ -42,64 +43,53 @@ export const Register = () => {
                 <h4>Hello! Lets get started</h4>
               </div>
 
-              <form className={styles.registerForm} onSubmit={handleSubmit(onSubmit)}>
-                <div className={styles.formContainer}>
-                  <div className={styles.formColLeft}>
-                    <Input
-                      attribute='firstName'
-                      label="First Name"
-                      register={register}
-                      isRequired={true}
-                      errors={errors}
-                    />
-                    <Input
-                      attribute='lastName'
-                      label="Last Name"
-                      register={register}
-                      isRequired={true}
-                      errors={errors}
-                    />
-                    <Input
-                      attribute='birthDate'
-                      label="Birth Date"
-                      register={register}
-                      isRequired={true}
-                      errors={errors}
-                      fieldType='date'
-                    />
+              <FormProvider {...methods}>
+                <form className={styles.registerForm} onSubmit={handleSubmit(onSubmit)}>
+                  <div className={styles.formContainer}>
+                    <div className={styles.formColLeft}>
+                      <Input
+                        attribute='firstName'
+                        label="First Name"
+                        isRequired={true}
+                      />
+                      <Input
+                        attribute='lastName'
+                        label="Last Name"
+                        isRequired={true}
+                      />
+                      <Input
+                        attribute='birthDate'
+                        label="Birth Date"
+                        isRequired={true}
+                        fieldType='date'
+                      />
+                    </div>
+                    <div className={styles.formColRight}>
+                      <Input
+                        attribute='email'
+                        label="Email"
+                        isRequired={true}
+                        ref={emailFieldRef}
+                      />
+                      <Input
+                        attribute='password'
+                        label="Password"
+                        isRequired={true}
+                        fieldType='password'
+                      />
+                      <Input
+                        attribute='repeatPassword'
+                        label="Re-type Password"
+                        isRequired={true}
+                        fieldType='password'
+                      />
+                    </div>
                   </div>
-                  <div className={styles.formColRight}>
-                    <Input
-                      attribute='email'
-                      label="Email"
-                      register={register}
-                      isRequired={true}
-                      errors={errors}
-                      ref={emailFieldRef}
-                    />
-                    <Input
-                      attribute='password'
-                      label="Password"
-                      register={register}
-                      isRequired={true}
-                      errors={errors}
-                      fieldType='password'
-                    />
-                    <Input
-                      attribute='repeatPassword'
-                      label="Re-type Password"
-                      register={register}
-                      isRequired={true}
-                      errors={errors}
-                      fieldType='password'
-                    />
+                  <div className={styles.buttonContainer}>
+                    <button className={sharedStyles.submitButton} type='submit' data-test='login-btn'>Register</button>
                   </div>
-                </div>
-                <div className={styles.buttonContainer}>
-                  <button className={sharedStyles.submitButton} type='submit' data-test='login-btn'>Register</button>
-                </div>
-              </form>
-
+                </form>
+              </FormProvider>
               <div className={styles.registerLinkContainer}>
                 Already have an account?
                 <Link to='/react-ui/login'>Sign in</Link>

--- a/application/react/_global/FilterBar/FilterBar.module.scss
+++ b/application/react/_global/FilterBar/FilterBar.module.scss
@@ -190,7 +190,5 @@
 .viewingResults {
   font-size: 14px;
   color: #676879;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  text-align: center;
 }

--- a/application/react/_global/FilterBar/FilterBar.module.scss
+++ b/application/react/_global/FilterBar/FilterBar.module.scss
@@ -190,6 +190,7 @@
 .viewingResults {
   font-size: 14px;
   color: #676879;
-  text-align: center;
-  margin-top: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { FieldErrors, FieldValues, UseFormRegister, Path, Controller, Control } from 'react-hook-form';
+import { FieldErrors, FieldValues, UseFormRegister, Path, Controller, Control, useFormContext, RegisterOptions } from 'react-hook-form';
 import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage.tsx';
 import clsx from 'clsx';
 import * as formStyles from '@ui/styles/form.module.scss'
@@ -16,27 +16,29 @@ type Props<T extends FieldValues> = {
   attribute: Path<T>,
   options: SelectOption[],
   label: string,
-  errors: FieldErrors,
+  errors?: FieldErrors,
   defaultValue?: string,
   isRequired?: boolean,
-  control: Control<T, any>,
-  register: UseFormRegister<T>,
+  control?: Control<T, any>,
+  register?: UseFormRegister<T>,
 }
 
 export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
-  const { attribute, options, label, errors, isRequired, control, register } = props;
+  const { attribute, options, label, isRequired } = props;
+  const formContext = useFormContext();
+  const { register, formState: { errors }, control } = formContext;
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   options.sort((a, b) => a.displayName?.localeCompare(b.displayName));
 
-  register(attribute, { required: isRequired ? "Nothing Selected" : undefined });
+  register(attribute, { required: isRequired ? "Nothing Selected" : undefined } as RegisterOptions);
 
   // Close dropdown if clicked outside
   useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
       }
     };

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { FieldErrors, FieldValues, UseFormRegister, Path, Controller, Control, useFormContext, RegisterOptions } from 'react-hook-form';
+import { FieldValues, Path, Controller, useFormContext, RegisterOptions } from 'react-hook-form';
 import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage.tsx';
 import clsx from 'clsx';
 import * as formStyles from '@ui/styles/form.module.scss'
@@ -16,11 +16,8 @@ type Props<T extends FieldValues> = {
   attribute: Path<T>,
   options: SelectOption[],
   label: string,
-  errors?: FieldErrors,
   defaultValue?: string,
   isRequired?: boolean,
-  control?: Control<T, any>,
-  register?: UseFormRegister<T>,
 }
 
 export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {

--- a/application/react/_global/FormInputs/Input/Input.tsx
+++ b/application/react/_global/FormInputs/Input/Input.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useState, useEffect } from 'react';
 import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage';
-import { FieldErrors, FieldValues, Path, UseFormRegister, RegisterOptions, useFormContext } from 'react-hook-form';
+import { FieldValues, Path, RegisterOptions, useFormContext } from 'react-hook-form';
 import { BsCurrencyDollar } from "react-icons/bs";
 import * as formStyles from '@ui/styles/form.module.scss'
 import clsx from 'clsx';
@@ -10,11 +10,8 @@ import * as textStyles from '@ui/styles/typography.module.scss';
 type Props<T extends FieldValues> = {
   attribute: Path<T>;
   label: string;
-  register?: UseFormRegister<T>;
-  errors?: FieldErrors;
   placeholder?: string;
   isRequired?: boolean;
-  additionalRegisterOptions?: any;
   onChange?: () => void;
   fieldType?: 'text' | 'checkbox' | 'date' | 'password' | 'currency' | 'percent';
   ref?: any;

--- a/application/react/_global/FormInputs/Input/Input.tsx
+++ b/application/react/_global/FormInputs/Input/Input.tsx
@@ -1,6 +1,6 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, useEffect } from 'react';
 import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage';
-import { FieldErrors, FieldValues, Path, UseFormRegister, RegisterOptions } from 'react-hook-form';
+import { FieldErrors, FieldValues, Path, UseFormRegister, RegisterOptions, useFormContext } from 'react-hook-form';
 import { BsCurrencyDollar } from "react-icons/bs";
 import * as formStyles from '@ui/styles/form.module.scss'
 import clsx from 'clsx';
@@ -10,8 +10,8 @@ import * as textStyles from '@ui/styles/typography.module.scss';
 type Props<T extends FieldValues> = {
   attribute: Path<T>;
   label: string;
-  register: UseFormRegister<T>;
-  errors: FieldErrors;
+  register?: UseFormRegister<T>;
+  errors?: FieldErrors;
   placeholder?: string;
   isRequired?: boolean;
   additionalRegisterOptions?: any;
@@ -31,14 +31,24 @@ interface WithForwardRefType extends React.FC<Props<FieldValues>> {
 }
 
 export const Input: WithForwardRefType = forwardRef((props, customRef) => {
-  const { placeholder, errors, attribute, label, register, isRequired, fieldType, dataAttributes, leftUnit, rightUnit, RightIcon, LeftIcon, defaultChecked } = props;
+  const { placeholder, attribute, label,  isRequired, fieldType, dataAttributes, leftUnit, rightUnit, RightIcon, LeftIcon, defaultChecked } = props;
   const [value, setValue] = useState('');
+  const formContext = useFormContext();
+  const {getValues, register, formState: { errors }} = formContext;
 
   const registerOptions: RegisterOptions = {
     required: isRequired ? 'This is required' : false,
   };
-
   const { ref, ...rest } = register(attribute, registerOptions);
+
+  useEffect(() => {
+    // Check if the field has a value from react-hook-form
+    const formValue = getValues(attribute);
+  
+    if (formValue) {
+      setValue(formValue);
+    }
+  }, [formContext, attribute]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
@@ -47,7 +57,7 @@ export const Input: WithForwardRefType = forwardRef((props, customRef) => {
     }
   };
 
-  const requiredFieldIsEmpty = isRequired && !value;
+  const requiredFieldIsEmpty = isRequired && (!value);
 
   return (
     <div className={clsx(formStyles.inputWrapper, styles.inputWrapper)}>

--- a/application/react/_global/FormInputs/TextArea/TextArea.tsx
+++ b/application/react/_global/FormInputs/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import { FieldErrors, FieldValues, Path, RegisterOptions, useFormContext, UseFormRegister } from 'react-hook-form';
+import { FieldValues, Path, RegisterOptions, useFormContext } from 'react-hook-form';
 import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage';
 import * as textStyles from '@ui/styles/typography.module.scss';
 import clsx from 'clsx';
@@ -7,8 +7,6 @@ import * as styles from './TextArea.module.scss';
 type Props<T extends FieldValues> = {
   attribute: Path<T>
   label: string
-  register?: UseFormRegister<T>
-  errors?: FieldErrors,
   isRequired?: boolean,
   placeholder?: string,
   dataAttributes?: { [key: `data-${string}`]: string },

--- a/application/react/_global/FormInputs/TextArea/TextArea.tsx
+++ b/application/react/_global/FormInputs/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import { FieldErrors, FieldValues, Path, UseFormRegister } from 'react-hook-form';
+import { FieldErrors, FieldValues, Path, RegisterOptions, useFormContext, UseFormRegister } from 'react-hook-form';
 import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage';
 import * as textStyles from '@ui/styles/typography.module.scss';
 import clsx from 'clsx';
@@ -7,8 +7,8 @@ import * as styles from './TextArea.module.scss';
 type Props<T extends FieldValues> = {
   attribute: Path<T>
   label: string
-  register: UseFormRegister<T>
-  errors: FieldErrors,
+  register?: UseFormRegister<T>
+  errors?: FieldErrors,
   isRequired?: boolean,
   placeholder?: string,
   dataAttributes?: { [key: `data-${string}`]: string },
@@ -17,18 +17,16 @@ type Props<T extends FieldValues> = {
 }
 
 export const TextArea = <T extends FieldValues>(props: Props<T>) => {
-  const { attribute, label, register, errors, isRequired, placeholder, dataAttributes, rows, cols } = props;
-
-  const { ...rest } = register(attribute,
-    { required: isRequired ? "This is required" : undefined }
-  );
+  const { attribute, label, isRequired, placeholder, dataAttributes, rows, cols } = props;
+  const formContext = useFormContext();
+  const { register, formState: { errors } } = formContext;
 
   return (
     <div className={styles.textAreaContainer}>
       <label>{label}<span className={clsx(textStyles.textRed, styles.requiredIndicator)}>{isRequired ? '*' : ''}</span></label>
       <textarea
         {...register(attribute,
-          { required: isRequired ? "This is required" : undefined }
+          { required: isRequired ? "This is required" : undefined } as RegisterOptions
         )}
         placeholder={placeholder}
         name={attribute}


### PR DESCRIPTION
# Description

I was creating a feature, where if a Form was loaded, and required input fields were empty, then we needed to style the border of those fields red.

This is easy for "create" forms, but for "update" forms, where data is queried, and then those input fields are dynamically populated (using react-hook-form `reset()`) method. The feature I had built out didn't work.

The fix for this was to wrap every form in a FormProvider (from react-hook-form). Then withinin the `Input` component,  utilize the `useFormContext`.

Now with a context, I no longer needed to prop drill form methods/data into the `Input` component, it was all available in the context. So this PR then made a huge refactor (updates to every form) to remove the prop drilling. 