### PR TITLE
`Cypress`: E2E Test `AdhesiveCategory`

### DIFF
--- a/application/api/models/adhesiveCategory.ts
+++ b/application/api/models/adhesiveCategory.ts
@@ -7,8 +7,11 @@ mongoose.plugin(mongooseDelete, { overrideMethods: true });
 
 const schema = new Schema<IAdhesiveCategory>({
     name: {
-        type: String,
-        required: true,
+      type: String,
+      required: true,
+      uppercase: true,
+      unique: true,
+      index: true
     },
 }, { timestamps: true, strict: 'throw' });
 

--- a/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
+++ b/application/react/CreditTerm/CreditTermForm/CreditTermForm.tsx
@@ -80,7 +80,7 @@ export const CreditTermForm = () => {
                   />
                 </div>
 
-                <Button color="blue" size="large">
+                <Button color="blue" size="large" data-test='submit-button'>
                   {isUpdateRequest ? 'Update' : 'Create'}
                 </Button>
               </div>

--- a/application/react/CreditTerm/CreditTermTable/CreditTermTable.tsx
+++ b/application/react/CreditTerm/CreditTermTable/CreditTermTable.tsx
@@ -34,7 +34,7 @@ export const CreditTermTable = () => {
   const confirmation = useConfirmation();
   const { ConfirmationDialog } = confirmation;
 
-  const columnHelper = createColumnHelper<any>()
+  const columnHelper = createColumnHelper<ICreditTerm>()
 
   const columns = [
     columnHelper.accessor('description', {
@@ -75,7 +75,7 @@ export const CreditTermTable = () => {
     useErrorMessage(error)
   }
 
-  const table = useReactTable<any>({
+  const table = useReactTable<ICreditTerm>({
     data: creditTermSearchResults?.results ?? defaultData,
     columns,
     rowCount: creditTermSearchResults?.totalResults ?? 0,
@@ -85,7 +85,6 @@ export const CreditTermTable = () => {
       globalFilter: globalSearch,
       sorting: sorting,
       pagination: pagination
-
     },
     onPaginationChange: setPagination,
     getCoreRowModel: getCoreRowModel(),
@@ -121,7 +120,7 @@ export const CreditTermTable = () => {
           }}
         />
 
-        <Table id='credit-term-table'>
+        <Table data-test='credit-term-table'>
           <TableHead table={table} />
 
           <TableBody>

--- a/cypress/e2e/adhesiveCategory.cy.ts
+++ b/cypress/e2e/adhesiveCategory.cy.ts
@@ -1,7 +1,9 @@
 describe('Adhesive Category Management', () => {
   const testCategory = {
-    name: `Test Category ${Date.now()}`
+    name: `Sample Name ${Date.now()}`
   };
+
+  const uppercasedName = testCategory.name.toUpperCase();
 
   beforeEach(() => {
     cy.login();
@@ -27,27 +29,16 @@ describe('Adhesive Category Management', () => {
     
     // Verify the new category appears in the table
     cy.get('[data-test=adhesive-category-table]')
-      .should('contain', testCategory.name);
+      .should('contain', uppercasedName);
   });
 
   it('should allow searching for an adhesive category', () => {
-    // First create a category if it doesn't exist
-    cy.get('[data-test=adhesive-category-table]').then($table => {
-      if (!$table.text().includes(testCategory.name)) {
-        cy.get('[data-test=create-icon-button]').click();
-        cy.get('[data-test=adhesive-category-form]').within(() => {
-          cy.get('[data-test=input-name]').type(testCategory.name);
-          cy.get('[data-test=submit-button]').click();
-        });
-      }
-    });
-
     // Search for the category
     cy.get('[data-test=searchbar]').type(testCategory.name);
     
     // Verify search results
     cy.get('[data-test=adhesive-category-table]')
-      .should('contain', testCategory.name);
+      .should('contain', uppercasedName);
   });
 
   it('should allow editing an existing adhesive category', () => {
@@ -55,7 +46,7 @@ describe('Adhesive Category Management', () => {
     
     // Find the row with our test category and click the edit button
     cy.get('[data-test=adhesive-category-table]')
-      .contains(testCategory.name)
+      .contains(uppercasedName)
       .closest('[data-test=table-row]')  // Get the row containing our text
       .find('[data-test=row-actions]')  // Find the actions container
       .find('[data-test=row-actions-button]')  // Find the button within actions
@@ -75,7 +66,7 @@ describe('Adhesive Category Management', () => {
 
     // Verify the update in the table
     cy.get('[data-test=adhesive-category-table]')
-      .should('contain', updatedName);
+      .should('contain', uppercasedName);
   });
 });
 

--- a/cypress/e2e/adhesiveCategory.cy.ts
+++ b/cypress/e2e/adhesiveCategory.cy.ts
@@ -1,9 +1,8 @@
-describe('Adhesive Category Management', () => {
-  const testCategory = {
-    name: `Sample Name ${Date.now()}`
-  };
+import { testDataGenerator } from "@/test-utils/cypress/testDataGenerator";
 
-  const uppercasedName = testCategory.name.toUpperCase();
+describe('Adhesive Category Management', () => {
+  const adhesiveCategory = testDataGenerator.AdhesiveCategory();
+  const uppercasedName = adhesiveCategory.name.toUpperCase();
 
   beforeEach(() => {
     cy.login();
@@ -20,7 +19,7 @@ describe('Adhesive Category Management', () => {
     
     // Fill out the form
     cy.get('[data-test=adhesive-category-form]').within(() => {
-      cy.get('[data-test=input-name]').type(testCategory.name);
+      cy.get('[data-test=input-name]').type(adhesiveCategory.name);
       cy.get('[data-test=submit-button]').click();
     });
 
@@ -34,7 +33,7 @@ describe('Adhesive Category Management', () => {
 
   it('should allow searching for an adhesive category', () => {
     // Search for the category
-    cy.get('[data-test=searchbar]').type(testCategory.name);
+    cy.get('[data-test=searchbar]').type(adhesiveCategory.name);
     
     // Verify search results
     cy.get('[data-test=adhesive-category-table]')
@@ -42,7 +41,7 @@ describe('Adhesive Category Management', () => {
   });
 
   it('should allow editing an existing adhesive category', () => {
-    const updatedName = `${testCategory.name} Updated`;
+    const updatedName = `${adhesiveCategory.name} Updated`;
     
     // Find the row with our test category and click the edit button
     cy.get('[data-test=adhesive-category-table]')

--- a/cypress/e2e/creditTerms.cy.ts
+++ b/cypress/e2e/creditTerms.cy.ts
@@ -1,0 +1,77 @@
+describe('Credit Term Management', () => {
+  const testCreditTerm = {
+    description: `Sample Description ${Date.now()}`
+  };
+
+  const uppercasedDescription = testCreditTerm.description.toUpperCase();
+
+  beforeEach(() => {
+    cy.login();
+    // Visit the table page first
+    cy.visit('/react-ui/tables/credit-term');
+  });
+
+  it('should allow creating and viewing a new credit term', () => {
+    // Click the create new button
+    cy.get('[data-test=create-icon-button]').click();
+    
+    // Verify we're on the form page
+    cy.url().should('include', '/react-ui/forms/credit-term');
+    
+    // Fill out the form
+    cy.get('[data-test=credit-term-form]').within(() => {
+      cy.get('[data-test=input-description]').type(testCreditTerm.description);
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Verify we're redirected back to the table
+    cy.url().should('include', '/react-ui/tables/credit-term');
+    
+    // Verify the new category appears in the table
+    cy.get('[data-test=credit-term-table]')
+      .should('exist') // waits for the table
+      .and('be.visible')
+      .should('contain', uppercasedDescription);
+  });
+
+  it('should allow searching for a credit term', () => {
+    // Search for the credit term
+    cy.get('[data-test=searchbar]').type(testCreditTerm.description);
+    
+    // Wait for the table to be ready and verify search results
+    cy.get('[data-test=credit-term-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=credit-term-table]')
+      .should('contain', uppercasedDescription);
+  });
+
+  it('should allow editing an existing credit term', () => {
+    const updatedDescription = `${testCreditTerm.description} Updated`;
+    
+    // Find the row with our test credit term and click the edit button
+    cy.get('[data-test=credit-term-table]')
+      .contains(uppercasedDescription)
+      .closest('[data-test=table-row]')  // Get the row containing our text
+      .find('[data-test=row-actions]')  // Find the actions container
+      .find('[data-test=row-actions-button]')  // Find the button within actions
+      .click();
+
+    // Click the edit button in the dropdown menu
+    cy.get('[data-test=row-actions-menu]')
+      .find('[data-test=row-action-item]')
+      .contains('Edit')
+      .click();
+
+    // Update the form
+    cy.get('[data-test=credit-term-form]').within(() => {
+      cy.get('[data-test=input-description]').clear().type(updatedDescription);
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Wait for the table to be ready and verify the update
+    cy.get('[data-test=credit-term-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=credit-term-table]')
+      .should('contain', updatedDescription.toUpperCase());
+  });
+});

--- a/cypress/e2e/creditTerms.cy.ts
+++ b/cypress/e2e/creditTerms.cy.ts
@@ -1,9 +1,8 @@
-describe('Credit Term Management', () => {
-  const testCreditTerm = {
-    description: `Sample Description ${Date.now()}`
-  };
+import { testDataGenerator } from '@test-utils/cypress/testDataGenerator';
 
-  const uppercasedDescription = testCreditTerm.description.toUpperCase();
+describe('Credit Term Management', () => {
+  const creditTerm = testDataGenerator.CreditTerm();
+  const uppercasedDescription = creditTerm.description.toUpperCase();
 
   beforeEach(() => {
     cy.login();
@@ -20,7 +19,7 @@ describe('Credit Term Management', () => {
     
     // Fill out the form
     cy.get('[data-test=credit-term-form]').within(() => {
-      cy.get('[data-test=input-description]').type(testCreditTerm.description);
+      cy.get('[data-test=input-description]').type(creditTerm.description);
       cy.get('[data-test=submit-button]').click();
     });
 
@@ -36,7 +35,7 @@ describe('Credit Term Management', () => {
 
   it('should allow searching for a credit term', () => {
     // Search for the credit term
-    cy.get('[data-test=searchbar]').type(testCreditTerm.description);
+    cy.get('[data-test=searchbar]').type(creditTerm.description);
     
     // Wait for the table to be ready and verify search results
     cy.get('[data-test=credit-term-table]').should('exist');
@@ -46,7 +45,7 @@ describe('Credit Term Management', () => {
   });
 
   it('should allow editing an existing credit term', () => {
-    const updatedDescription = `${testCreditTerm.description} Updated`;
+    const updatedDescription = `${creditTerm.description} Updated`;
     
     // Find the row with our test credit term and click the edit button
     cy.get('[data-test=credit-term-table]')

--- a/cypress/support/testData.ts
+++ b/cypress/support/testData.ts
@@ -5,4 +5,4 @@ export const TEST_USER = {
     email: 'test@example.com',
     password: 'password123',
     authRoles: ['ADMIN']
-}; 
+};

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -11,6 +11,7 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
+      "@/*": ["../*"],
       "@test-utils/*": ["../test-utils/*"]
     }
   },

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["../../*"]
+      "@/*": ["../*"],
+      "@test-utils/*": ["../test-utils/*"]
     }
   },
   "include": [

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -11,7 +11,6 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["../*"],
       "@test-utils/*": ["../test-utils/*"]
     }
   },

--- a/test-utils/cypress/testDataGenerator.ts
+++ b/test-utils/cypress/testDataGenerator.ts
@@ -2,13 +2,3 @@ import { mockData } from '../testDataGenerator';
 
 // Re-export the mock data generator
 export const testDataGenerator = mockData;
-
-// Add any Cypress-specific test data generation functions here
-export const generateUniqueTestData = () => {
-  // Add any Cypress-specific logic for generating unique test data
-  // For example, adding timestamps or unique identifiers
-  return {
-    ...mockData,
-    // Add any overrides or additional generators here
-  };
-}; 

--- a/test-utils/cypress/testDataGenerator.ts
+++ b/test-utils/cypress/testDataGenerator.ts
@@ -1,0 +1,14 @@
+import { mockData } from '../testDataGenerator';
+
+// Re-export the mock data generator
+export const testDataGenerator = mockData;
+
+// Add any Cypress-specific test data generation functions here
+export const generateUniqueTestData = () => {
+  // Add any Cypress-specific logic for generating unique test data
+  // For example, adding timestamps or unique identifiers
+  return {
+    ...mockData,
+    // Add any overrides or additional generators here
+  };
+}; 

--- a/test-utils/testDataGenerator.ts
+++ b/test-utils/testDataGenerator.ts
@@ -20,7 +20,9 @@ export const mockData = {
     Contact: getContact,
     User: getUser,
     BaseProduct: getBaseProduct,
-    Address: getAddress
+    Address: getAddress,
+    CreditTerm: getCreditTerm,
+    AdhesiveCategory: getAdhesiveCategory
 };
 
 function getDie() {
@@ -49,6 +51,18 @@ function getDie() {
         status: chance.pickone(dieStatuses),
         quantity: chance.d100(),
         isLamination: chance.pickone([chance.bool(), undefined])
+    };
+}
+
+function getCreditTerm() {
+    return {
+        description: chance.string()
+    };
+}
+
+function getAdhesiveCategory() {
+    return {
+        name: chance.string()
     };
 }
 

--- a/test/models/adhesiveCategory.spec.js
+++ b/test/models/adhesiveCategory.spec.js
@@ -42,8 +42,18 @@ describe('validation', () => {
             adhesiveCategoryAttributes.name = '   ' + expectedName + '  ';
             const downtimeReason = new AdhesiveCategoryModel(adhesiveCategoryAttributes);
 
-            expect(downtimeReason.name).toEqual(expectedName);
+            expect(downtimeReason.name).toEqual(expectedName.toUpperCase());
         });
+
+        it('should upper case attribute', () => {
+            const lowerCaseName = chance.string().toLowerCase();
+            adhesiveCategoryAttributes.name = lowerCaseName;
+
+            const adhesiveCategory = new AdhesiveCategoryModel(adhesiveCategoryAttributes);
+
+            expect(adhesiveCategory.name).toEqual(lowerCaseName.toUpperCase());
+        });
+
     });
 
     describe('verify timestamps on created object', () => {

--- a/test/models/baseProduct.spec.js
+++ b/test/models/baseProduct.spec.js
@@ -7,7 +7,7 @@ import { MaterialModel } from '../../application/api/models/material.ts';
 import { unwindDirections } from '../../application/api/enums/unwindDirectionsEnum';
 import { finishTypes } from '../../application/api/enums/finishTypesEnum';
 import { DieModel } from '../../application/api/models/die.ts';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 
 jest.mock('../../application/api/services/materialInventoryService.ts');
 

--- a/test/models/customer.spec.js
+++ b/test/models/customer.spec.js
@@ -2,7 +2,7 @@ import mongoose from 'mongoose';
 import Chance from 'chance';
 import { CustomerModel } from '../../application/api/models/customer.ts';
 import * as databaseService from '../../application/api/services/databaseService';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 
 const chance = Chance();
 

--- a/test/models/die.spec.js
+++ b/test/models/die.spec.js
@@ -6,7 +6,7 @@ import { dieVendors } from '../../application/api/enums/dieVendorsEnum';
 import { dieMagCylinders } from '../../application/api/enums/dieMagCylindersEnum';
 import { dieStatuses, IN_STOCK_DIE_STATUS, ORDERED_DIE_STATUS } from '../../application/api/enums/dieStatusesEnum';
 import * as databaseService from '../../application/api/services/databaseService';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 
 const chance = Chance();
 

--- a/test/models/finish.spec.js
+++ b/test/models/finish.spec.js
@@ -3,7 +3,7 @@ const chance = Chance();
 import mongoose from 'mongoose';
 import { FinishModel } from '../../application/api/models/finish.ts';
 import * as databaseService from '../../application/api/services/databaseService';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 
 describe('validation', () => {
     let finishAttributes;

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -2,7 +2,7 @@ import Chance from 'chance';
 import { MaterialModel } from '../../application/api/models/material.ts';
 import mongoose from 'mongoose';
 import * as databaseService from '../../application/api/services/databaseService';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 import { populateMaterialInventories as populateMaterialInventoriesMock } from '../../application/api/services/materialInventoryService.ts';
 import { when } from 'jest-when';
 

--- a/test/models/newTicket.spec.js
+++ b/test/models/newTicket.spec.js
@@ -6,7 +6,7 @@ import * as departmentsEnum from '../../application/api/enums/departmentsEnum.ts
 import * as databaseService from '../../application/api/services/databaseService';
 import mongoose from 'mongoose';
 
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 
 const chance = Chance();
 

--- a/test/models/packingSlip.spec.js
+++ b/test/models/packingSlip.spec.js
@@ -1,7 +1,7 @@
 import { PackingSlipModel } from '../../application/api/models/packingSlip';
 import Chance from 'chance';
 import * as databaseService from '../../application/api/services/databaseService';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 import mongoose from 'mongoose';
 
 const chance = Chance();

--- a/test/models/quote.spec.js
+++ b/test/models/quote.spec.js
@@ -3,7 +3,7 @@ import { QuoteModel } from '../../application/api/models/quote.ts';
 import * as databaseService from '../../application/api/services/databaseService';
 import mongoose from 'mongoose';
 import * as constants from '../../application/api/enums/constantsEnum.ts';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 import { unwindDirections } from '../../application/api/enums/unwindDirectionsEnum';
 import Chance from 'chance';
 

--- a/test/models/user.spec.js
+++ b/test/models/user.spec.js
@@ -1,6 +1,6 @@
 import Chance from 'chance';
 import { UserModel } from '../../application/api/models/user.ts';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 import { AVAILABLE_AUTH_ROLES } from '../../application/api/enums/authRolesEnum.ts';
 import * as databaseService from '../../application/api/services/databaseService';
 import mongoose from 'mongoose';

--- a/test/models/vendor.spec.js
+++ b/test/models/vendor.spec.js
@@ -2,7 +2,7 @@ import Chance from 'chance';
 import { VendorModel } from '../../application/api/models/vendor.ts';
 import * as databaseService from '../../application/api/services/databaseService';
 import mongoose from 'mongoose';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 
 const chance = Chance();
 

--- a/test/services/baseProductService.spec.js
+++ b/test/services/baseProductService.spec.js
@@ -1,6 +1,6 @@
 import { BaseProductModel } from '../../application/api/models/baseProduct.ts';
 import * as databaseService from '../../application/api/services/databaseService';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 import { FinishModel } from '../../application/api/models/finish.ts';
 import { MaterialModel } from '../../application/api/models/material.ts';
 import { CustomerModel } from '../../application/api/models/customer.ts';

--- a/test/services/quoteService.spec.js
+++ b/test/services/quoteService.spec.js
@@ -5,7 +5,7 @@ import Chance from 'chance';
 import mongoose from 'mongoose';
 import { when } from 'jest-when';
 import { convertMinutesToSeconds, convertSecondsToMinutes } from '../../application/api/services/dateTimeService.ts';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 import * as databaseService from '../../application/api/services/databaseService';
 
 const chance = Chance();

--- a/test/services/userService.spec.js
+++ b/test/services/userService.spec.js
@@ -3,7 +3,7 @@ import * as databaseService from '../../application/api/services/databaseService
 import { UserModel } from '../../application/api/models/user.ts';
 import jwt from 'jsonwebtoken';
 import Chance from 'chance';
-import * as testDataGenerator from '../testDataGenerator';
+import * as testDataGenerator from '../../test-utils/testDataGenerator.ts';
 
 const chance = Chance();
 


### PR DESCRIPTION
# Description

This PR adds E2E tests for AdhesiveCategory - specifically around the table and form. More specifically around Creating/Updating/Viewing (Deletion coming eventually)

We also generate randomized data in our unit tests for each of our database entities, including adhesiveCategories - so I migrated that file `testDataGenerator.ts` into a shared folder so both unit tests and cypress can use it. When we get around to really complex entities, I don't realllllly feel like hardcoding 25 different attributes that must match specific validation rules - when all that is already setup and working via the testDataGenerator (thanks past me)