### PR TITLE
Expand Cypress Test Coverage

### DIFF
--- a/application/api/enums/dieNumberPrefixEnum.ts
+++ b/application/api/enums/dieNumberPrefixEnum.ts
@@ -1,0 +1,1 @@
+export const DIE_NUMBER_PREFIXES = ['DC', 'DR', 'DRC' , 'DO', 'DS', 'XLDR', 'DSS', 'DB'];

--- a/application/api/index.ts
+++ b/application/api/index.ts
@@ -12,9 +12,10 @@ import httpServ from 'http';
 import { Server } from 'socket.io';
 import customWebSockets from './services/websockets/init.ts';
 import { setupApiRoutes } from './routes.ts'
-import { connectToTestDatabase } from '../../test/sharedTestDatabase';
+import { connectToTestDatabase, removeTestDbUriFile } from '../../test/sharedTestDatabase';
 
 if (process.env.NODE_ENV === 'test') {
+    removeTestDbUriFile();  // Remove the test database file if it exists
     connectToTestDatabase();
 } else {
     connectToMongoDatabase(process.env.MONGO_DB_URL);

--- a/application/api/models/die.ts
+++ b/application/api/models/die.ts
@@ -8,11 +8,11 @@ import { dieMagCylinders } from '../enums/dieMagCylindersEnum.ts';
 import { dieStatuses, ORDERED_DIE_STATUS, IN_STOCK_DIE_STATUS } from '../enums/dieStatusesEnum.ts';
 import { convertDollarsToPennies, convertPenniesToDollars } from '../services/currencyService.ts';
 import { IDie } from '@shared/types/models.ts';
+import { DIE_NUMBER_PREFIXES } from '../enums/dieNumberPrefixEnum.ts';
 
 import mongooseDelete from 'mongoose-delete';
 mongoose.plugin(mongooseDelete, { overrideMethods: true });
 
-const DIE_NUMBER_PREFIXES = ['DC', 'DR', 'DRC' , 'DO', 'DS', 'XLDR', 'DSS', 'DB'];
 const DIE_NUMBER_REGEX = /^(\d{4})$/;
 
 function validateDieNumberFormat(dieNumber) {

--- a/application/react/DeliveryMethod/DeliveryMethodForm/DeliveryMethodForm.tsx
+++ b/application/react/DeliveryMethod/DeliveryMethodForm/DeliveryMethodForm.tsx
@@ -73,7 +73,7 @@ export const DeliveryMethodForm = () => {
                     isRequired={true}
                   />
                 </div>
-                <Button color="blue" size="large">
+                <Button color="blue" size="large" data-test='submit-button'>
                   {isUpdateRequest ? 'Update' : 'Create'}
                 </Button>
               </div>

--- a/application/react/DeliveryMethod/DeliveryMethodTable/DeliveryMethodTable.tsx
+++ b/application/react/DeliveryMethod/DeliveryMethodTable/DeliveryMethodTable.tsx
@@ -91,7 +91,7 @@ function DeliveryMethodTable() {
           }}
         />
 
-        <Table id='delivery-method-table'>
+        <Table id='delivery-method-table' data-test='delivery-method-table'>
           <TableHead table={table} />
 
           <TableBody>

--- a/application/react/Die/DieForm/DieForm.tsx
+++ b/application/react/Die/DieForm/DieForm.tsx
@@ -237,7 +237,7 @@ export const DieForm = () => {
                 />
               </div>
 
-              <Button color="blue" size="large">
+              <Button color="blue" size="large" data-test='submit-button'>
                 {isUpdateRequest ? 'Update' : 'Create'}
               </Button>
             </div>

--- a/application/react/Die/DieTable/DieTable.tsx
+++ b/application/react/Die/DieTable/DieTable.tsx
@@ -35,6 +35,12 @@ export const DieTable = () => {
     columnHelper.accessor('dieNumber', {
       header: 'Die Number',
     }),
+    columnHelper.accessor('serialNumber', {
+      header: 'Serial Number',
+    }),
+    columnHelper.accessor('status', {
+      header: 'Status',
+    }),
     columnHelper.accessor(row => getDateTimeFromIsoStr(row.updatedAt), {
       header: 'Updated'
     }),

--- a/application/react/Die/DieTable/DieTable.tsx
+++ b/application/react/Die/DieTable/DieTable.tsx
@@ -116,7 +116,7 @@ export const DieTable = () => {
           }}
         />
 
-        <Table id='die-table'>
+        <Table id='die-table' data-test='die-table'>
           <TableHead table={table} />
 
           <TableBody>

--- a/application/react/LinerType/LinerTypeForm/LinerTypeForm.tsx
+++ b/application/react/LinerType/LinerTypeForm/LinerTypeForm.tsx
@@ -79,7 +79,7 @@ export const LinerTypeForm = () => {
                 />
               </div>
 
-              <Button color="blue" size="large">
+              <Button color="blue" size="large" data-test='submit-button'>
                 {isUpdateRequest ? 'Update' : 'Create'}
               </Button>
             </div>

--- a/application/react/LinerType/LinerTypeTable/LinerTypeTable.tsx
+++ b/application/react/LinerType/LinerTypeTable/LinerTypeTable.tsx
@@ -120,7 +120,7 @@ export const LinerTypeTable = () => {
           }}
         />
 
-        <Table id='liner-type-table'>
+        <Table id='liner-type-table' data-test='liner-type-table'>
           <TableHead table={table} />
 
           <TableBody>

--- a/application/react/Material/MaterialForm/MaterialForm.tsx
+++ b/application/react/Material/MaterialForm/MaterialForm.tsx
@@ -350,7 +350,7 @@ export const MaterialForm = () => {
                 />
               </div>
 
-              <Button color="blue" size="large">
+              <Button color="blue" size="large" data-test='submit-button'>
                 {isUpdateRequest ? 'Update' : 'Create'}
               </Button>
             </div>

--- a/application/react/Material/MaterialTable/MaterialTable.tsx
+++ b/application/react/Material/MaterialTable/MaterialTable.tsx
@@ -129,7 +129,7 @@ export const MaterialTable = () => {
           }}
         />
 
-        <Table id='material-table'>
+        <Table data-test='material-table'>
           <TableHead table={table} />
 
           <TableBody>

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
@@ -59,6 +59,11 @@ export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
   const doesValueExist: boolean = isMulti ? value && value.length > 0 : value;
   const requiredFieldIsEmpty = isRequired && (!value || (isMulti && value.length === 0));
 
+  // Generate data-test attribute, used by cypress tests
+  const testAttribute = {
+    'data-test': `input-${attribute}`
+  };
+
   return (
     <div className={clsx(formStyles.customSelectContainer)} ref={dropdownRef}>
       <label className={styles.customSelectLabel}>{label}<span className={clsx(textStyles.textRed, styles.requiredIndicator)}>{isRequired ? '*' : ''}</span></label>
@@ -66,7 +71,7 @@ export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
         control={control}
         name={attribute}
         render={({ field: { onChange, value } }) => (
-          <div>
+          <div {...testAttribute}>
             {/* Selected Option */}
             <div 
               className={clsx(
@@ -86,7 +91,7 @@ export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
 
             {/* Dropdown Options */}
             {isOpen && (
-              <div className={styles.selectItemsDropdown}>
+              <div className={styles.selectItemsDropdown} data-test='select-items-dropdown'>
                 {/* Search Input */}
                 <input
                   type="text"
@@ -95,6 +100,7 @@ export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   autoFocus
+                  data-test="select-search-input"
                 />
 
                 {/* "Nothing Selected" Option */}
@@ -155,13 +161,12 @@ type DropdownOptionProps = {
 }
 
 const DropdownOption = ({ option, key, onClick, isSelected, className = '' }: DropdownOptionProps) => {
-
   return (
     <div
       key={key}
       className={clsx(styles.dropdownItem, className, isSelected && styles.sameAsSelected)}
       onClick={onClick}
-
+      data-test="select-dropdown-item"
     >
       {option.displayName}
     </div>

--- a/application/react/_global/FormInputs/TextArea/TextArea.tsx
+++ b/application/react/_global/FormInputs/TextArea/TextArea.tsx
@@ -19,6 +19,10 @@ export const TextArea = <T extends FieldValues>(props: Props<T>) => {
   const formContext = useFormContext();
   const { register, formState: { errors } } = formContext;
 
+  const testAttribute = {
+    'data-test': `input-${attribute}`
+  };
+
   return (
     <div className={styles.textAreaContainer}>
       <label>{label}<span className={clsx(textStyles.textRed, styles.requiredIndicator)}>{isRequired ? '*' : ''}</span></label>
@@ -28,6 +32,7 @@ export const TextArea = <T extends FieldValues>(props: Props<T>) => {
         )}
         placeholder={placeholder}
         name={attribute}
+        {...testAttribute}
         {...dataAttributes}
         {...(rows ? { rows: rows } : {})}
         {...(cols ? { cols: cols } : {})}

--- a/cypress/e2e/deliveryMethod.cy.ts
+++ b/cypress/e2e/deliveryMethod.cy.ts
@@ -1,0 +1,76 @@
+import { testDataGenerator } from '@test-utils/cypress/testDataGenerator';
+
+describe('Delivery Method Management', () => {
+  const deliveryMethod = testDataGenerator.DeliveryMethod();
+  const uppercasedName = deliveryMethod.name.toUpperCase();
+
+  beforeEach(() => {
+    cy.login();
+    // Visit the table page first
+    cy.visit('/react-ui/tables/delivery-method');
+  });
+
+  it('should allow creating and viewing a new delivery method', () => {
+    // Click the create new button
+    cy.get('[data-test=create-icon-button]').click();
+    
+    // Verify we're on the form page
+    cy.url().should('include', '/react-ui/forms/delivery-method');
+    
+    // Fill out the form
+    cy.get('[data-test=delivery-method-form]').within(() => {
+      cy.get('[data-test=input-name]').type(deliveryMethod.name);
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Verify we're redirected back to the table
+    cy.url().should('include', '/react-ui/tables/delivery-method');
+    
+    // Verify the new delivery method appears in the table
+    cy.get('[data-test=delivery-method-table]')
+      .should('exist') // waits for the table
+      .and('be.visible')
+      .should('contain', uppercasedName);
+  });
+
+  it('should allow searching for a delivery method', () => {
+    // Search for the delivery method
+    cy.get('[data-test=searchbar]').type(deliveryMethod.name);
+    
+    // Wait for the table to be ready and verify search results
+    cy.get('[data-test=delivery-method-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=delivery-method-table]')
+      .should('contain', uppercasedName);
+  });
+
+  it('should allow editing an existing delivery method', () => {
+    const updatedName = `${deliveryMethod.name} Updated`;
+    
+    // Find the row with our test delivery method and click the edit button
+    cy.get('[data-test=delivery-method-table]')
+      .contains(uppercasedName)
+      .closest('[data-test=table-row]')  // Get the row containing our text
+      .find('[data-test=row-actions]')  // Find the actions container
+      .find('[data-test=row-actions-button]')  // Find the button within actions
+      .click();
+
+    // Click the edit button in the dropdown menu
+    cy.get('[data-test=row-actions-menu]')
+      .find('[data-test=row-action-item]')
+      .contains('Edit')
+      .click();
+
+    // Update the form
+    cy.get('[data-test=delivery-method-form]').within(() => {
+      cy.get('[data-test=input-name]').clear().type(updatedName);
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Wait for the table to be ready and verify the update
+    cy.get('[data-test=delivery-method-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=delivery-method-table]')
+      .should('contain', updatedName.toUpperCase());
+  });
+});

--- a/cypress/e2e/die.cy.ts
+++ b/cypress/e2e/die.cy.ts
@@ -1,6 +1,6 @@
 import { testDataGenerator } from '@test-utils/cypress/testDataGenerator';
 
-describe.only('Die Management', () => {
+describe('Die Management', () => {
   const die = testDataGenerator.Die();
   const uppercasedName = die.dieNumber.toUpperCase();
 
@@ -21,9 +21,9 @@ describe.only('Die Management', () => {
     cy.get('[data-test=die-form]').within(() => {
       // Basic Information
       cy.get('[data-test=input-dieNumber]').type(die.dieNumber);
-      cy.selectFromCustomSelect('[data-test=input-shape]', die.shape);
+      cy.selectFromDropdown('[data-test=input-shape]', die.shape);
       cy.get('[data-test=input-quantity]').type(die.quantity.toString());
-      cy.selectFromCustomSelect('[data-test=input-status]', die.status);
+      cy.selectFromDropdown('[data-test=input-status]', die.status);
 
       // Size Information
       cy.get('[data-test=input-sizeAcross]').type(die.sizeAcross.toString());
@@ -36,18 +36,18 @@ describe.only('Die Management', () => {
 
       // Tool Information
       cy.get('[data-test=input-gear]').type(die.gear);
-      cy.selectFromCustomSelect('[data-test=input-toolType]', die.toolType);
-      cy.selectFromCustomSelect('[data-test=input-magCylinder]', die.magCylinder.toString());
+      cy.selectFromDropdown('[data-test=input-toolType]', die.toolType);
+      cy.selectFromDropdown('[data-test=input-magCylinder]', die.magCylinder.toString());
       cy.get('[data-test=input-facestock]').type(die.facestock);
       cy.get('[data-test=input-liner]').type(die.liner);
       cy.get('[data-test=input-specialType]').type(die.specialType || '');
 
       // Additional Information
       cy.get('[data-test=input-cost]').type(die.cost.toString());
-      cy.selectFromCustomSelect('[data-test=input-vendor]', die.vendor);
+      cy.selectFromDropdown('[data-test=input-vendor]', die.vendor);
       cy.get('[data-test=input-serialNumber]').type(die.serialNumber);
       if (die.isLamination) {
-        cy.get('[data-test=input-isLamination]').check();
+        cy.get('[data-test=input-isLamination]').check(); // TODO: Make this a command
       }
 
       // Notes

--- a/cypress/e2e/die.cy.ts
+++ b/cypress/e2e/die.cy.ts
@@ -1,0 +1,80 @@
+import { testDataGenerator } from '@test-utils/cypress/testDataGenerator';
+
+describe.only('Die Management', () => {
+  const die = testDataGenerator.Die();
+  const uppercasedName = die.dieNumber.toUpperCase();
+
+  beforeEach(() => {
+    cy.login();
+    // Visit the table page first
+    cy.visit('/react-ui/tables/die');
+  });
+
+  it('should allow creating and viewing a new die', () => {
+    // Click the create new button
+    cy.get('[data-test=create-icon-button]').click();
+    
+    // Verify we're on the form page
+    cy.url().should('include', '/react-ui/forms/die');
+    
+    // Fill out the form
+    cy.get('[data-test=die-form]').within(() => {
+      cy.get('[data-test=input-dieNumber]').type(die.dieNumber);
+      
+      // Select shape from CustomSelect using the custom command
+      cy.selectFromCustomSelect('[data-test=input-shape]', die.shape);
+      
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Verify we're redirected back to the table
+    cy.url().should('include', '/react-ui/tables/die');
+    
+    // Verify the new delivery method appears in the table
+    cy.get('[data-test=die-table]')
+      .should('exist') // waits for the table
+      .and('be.visible')
+      .should('contain', uppercasedName);
+  });
+
+  it('should allow searching for a delivery method', () => {
+    // Search for the delivery method
+    cy.get('[data-test=searchbar]').type(die.dieNumber);
+    
+    // Wait for the table to be ready and verify search results
+    cy.get('[data-test=die-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=die-table]')
+      .should('contain', uppercasedName);
+  });
+
+  it('should allow editing an existing die', () => {
+    const updatedName = `${die.dieNumber} Updated`;
+    
+    // Find the row with our test delivery method and click the edit button
+    cy.get('[data-test=die-table]')
+      .contains(uppercasedName)
+      .closest('[data-test=table-row]')  // Get the row containing our text
+      .find('[data-test=row-actions]')  // Find the actions container
+      .find('[data-test=row-actions-button]')  // Find the button within actions
+      .click();
+
+    // Click the edit button in the dropdown menu
+    cy.get('[data-test=row-actions-menu]')
+      .find('[data-test=row-action-item]')
+      .contains('Edit')
+      .click();
+
+    // Update the form
+    cy.get('[data-test=die-form]').within(() => {
+      cy.get('[data-test=input-dieNumber]').clear().type(updatedName);
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Wait for the table to be ready and verify the update
+    cy.get('[data-test=die-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=die-table]')
+      .should('contain', updatedName.toUpperCase());
+  });
+});

--- a/cypress/e2e/die.cy.ts
+++ b/cypress/e2e/die.cy.ts
@@ -47,7 +47,7 @@ describe('Die Management', () => {
       cy.selectFromDropdown('[data-test=input-vendor]', die.vendor);
       cy.get('[data-test=input-serialNumber]').type(die.serialNumber);
       if (die.isLamination) {
-        cy.get('[data-test=input-isLamination]').check(); // TODO: Make this a command
+        cy.get('[data-test=input-isLamination]').check();
       }
 
       // Notes
@@ -59,15 +59,15 @@ describe('Die Management', () => {
     // Verify we're redirected back to the table
     cy.url().should('include', '/react-ui/tables/die');
     
-    // Verify the new delivery method appears in the table
+    // Verify the new die appears in the table
     cy.get('[data-test=die-table]')
       .should('exist') // waits for the table
       .and('be.visible')
       .should('contain', uppercasedName);
   });
 
-  it('should allow searching for a delivery method', () => {
-    // Search for the delivery method
+  it('should allow searching for a die', () => {
+    // Search for the die
     cy.get('[data-test=searchbar]').type(die.dieNumber);
     
     // Wait for the table to be ready and verify search results
@@ -80,7 +80,7 @@ describe('Die Management', () => {
   it('should allow editing an existing die', () => {
     const updatedSerialNumber = die.serialNumber + ' Updated';
     
-    // Find the row with our test delivery method and click the edit button
+    // Find the row with our test die and click the edit button
     cy.get('[data-test=die-table]')
       .contains(uppercasedName)
       .closest('[data-test=table-row]')  // Get the row containing our text

--- a/cypress/e2e/die.cy.ts
+++ b/cypress/e2e/die.cy.ts
@@ -19,10 +19,39 @@ describe.only('Die Management', () => {
     
     // Fill out the form
     cy.get('[data-test=die-form]').within(() => {
+      // Basic Information
       cy.get('[data-test=input-dieNumber]').type(die.dieNumber);
-      
-      // Select shape from CustomSelect using the custom command
       cy.selectFromCustomSelect('[data-test=input-shape]', die.shape);
+      cy.get('[data-test=input-quantity]').type(die.quantity.toString());
+      cy.selectFromCustomSelect('[data-test=input-status]', die.status);
+
+      // Size Information
+      cy.get('[data-test=input-sizeAcross]').type(die.sizeAcross.toString());
+      cy.get('[data-test=input-sizeAround]').type(die.sizeAround.toString());
+      cy.get('[data-test=input-numberAcross]').type(die.numberAcross.toString());
+      cy.get('[data-test=input-numberAround]').type(die.numberAround.toString());
+      cy.get('[data-test=input-cornerRadius]').type(die.cornerRadius.toString());
+      cy.get('[data-test=input-topAndBottom]').type(die.topAndBottom.toString());
+      cy.get('[data-test=input-leftAndRight]').type(die.leftAndRight.toString());
+
+      // Tool Information
+      cy.get('[data-test=input-gear]').type(die.gear);
+      cy.selectFromCustomSelect('[data-test=input-toolType]', die.toolType);
+      cy.selectFromCustomSelect('[data-test=input-magCylinder]', die.magCylinder.toString());
+      cy.get('[data-test=input-facestock]').type(die.facestock);
+      cy.get('[data-test=input-liner]').type(die.liner);
+      cy.get('[data-test=input-specialType]').type(die.specialType || '');
+
+      // Additional Information
+      cy.get('[data-test=input-cost]').type(die.cost.toString());
+      cy.selectFromCustomSelect('[data-test=input-vendor]', die.vendor);
+      cy.get('[data-test=input-serialNumber]').type(die.serialNumber);
+      if (die.isLamination) {
+        cy.get('[data-test=input-isLamination]').check();
+      }
+
+      // Notes
+      cy.get('[data-test=input-notes]').type(die.notes);
       
       cy.get('[data-test=submit-button]').click();
     });
@@ -49,7 +78,7 @@ describe.only('Die Management', () => {
   });
 
   it('should allow editing an existing die', () => {
-    const updatedName = `${die.dieNumber} Updated`;
+    const updatedSerialNumber = die.serialNumber + ' Updated';
     
     // Find the row with our test delivery method and click the edit button
     cy.get('[data-test=die-table]')
@@ -67,7 +96,7 @@ describe.only('Die Management', () => {
 
     // Update the form
     cy.get('[data-test=die-form]').within(() => {
-      cy.get('[data-test=input-dieNumber]').clear().type(updatedName);
+      cy.get('[data-test=input-serialNumber]').clear().type(updatedSerialNumber);
       cy.get('[data-test=submit-button]').click();
     });
 
@@ -75,6 +104,6 @@ describe.only('Die Management', () => {
     cy.get('[data-test=die-table]').should('exist');
     cy.get('[data-test=table-row]').should('exist');
     cy.get('[data-test=die-table]')
-      .should('contain', updatedName.toUpperCase());
+      .should('contain', updatedSerialNumber);
   });
 });

--- a/cypress/e2e/linerType.cy.ts
+++ b/cypress/e2e/linerType.cy.ts
@@ -26,13 +26,13 @@ describe('Liner Type Management', () => {
     // Verify we're redirected back to the table
     cy.url().should('include', '/react-ui/tables/liner-type');
     
-    // Verify the new category appears in the table
+    // Verify the new liner type appears in the table
     cy.get('[data-test=liner-type-table]')
       .should('contain', uppercasedName);
   });
 
   it('should allow searching for a liner type', () => {
-    // Search for the category
+    // Search for the liner type
     cy.get('[data-test=searchbar]').type(linerType.name);
     
     // Verify search results
@@ -43,7 +43,7 @@ describe('Liner Type Management', () => {
   it('should allow editing an existing liner type', () => {
     const updatedName = `${linerType.name} Updated`;
     
-    // Find the row with our test category and click the edit button
+    // Find the row with our test liner type and click the edit button
     cy.get('[data-test=liner-type-table]')
       .contains(uppercasedName)
       .closest('[data-test=table-row]')  // Get the row containing our text

--- a/cypress/e2e/linerType.cy.ts
+++ b/cypress/e2e/linerType.cy.ts
@@ -1,0 +1,72 @@
+import { testDataGenerator } from "@/test-utils/cypress/testDataGenerator";
+
+describe('Liner Type Management', () => {
+  const linerType = testDataGenerator.LinerType();
+  const uppercasedName = linerType.name.toUpperCase();
+
+  beforeEach(() => {
+    cy.login();
+    // Visit the table page first
+    cy.visit('/react-ui/tables/liner-type');
+  });
+
+  it('should allow creating and viewing a new liner type', () => {
+    // Click the create new button
+    cy.get('[data-test=create-icon-button]').click();
+    
+    // Verify we're on the form page
+    cy.url().should('include', '/react-ui/forms/liner-type');
+    
+    // Fill out the form
+    cy.get('[data-test=liner-type-form]').within(() => {
+      cy.get('[data-test=input-name]').type(linerType.name);
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Verify we're redirected back to the table
+    cy.url().should('include', '/react-ui/tables/liner-type');
+    
+    // Verify the new category appears in the table
+    cy.get('[data-test=liner-type-table]')
+      .should('contain', uppercasedName);
+  });
+
+  it('should allow searching for a liner type', () => {
+    // Search for the category
+    cy.get('[data-test=searchbar]').type(linerType.name);
+    
+    // Verify search results
+    cy.get('[data-test=liner-type-table]')
+      .should('contain', uppercasedName);
+  });
+
+  it('should allow editing an existing liner type', () => {
+    const updatedName = `${linerType.name} Updated`;
+    
+    // Find the row with our test category and click the edit button
+    cy.get('[data-test=liner-type-table]')
+      .contains(uppercasedName)
+      .closest('[data-test=table-row]')  // Get the row containing our text
+      .find('[data-test=row-actions]')  // Find the actions container
+      .find('[data-test=row-actions-button]')  // Find the button within actions
+      .click();
+
+    // Click the edit button in the dropdown menu
+    cy.get('[data-test=row-actions-menu]')
+      .find('[data-test=row-action-item]')
+      .contains('Edit')
+      .click();
+
+    // Update the form
+    cy.get('[data-test=liner-type-form]').within(() => {
+      cy.get('[data-test=input-name]').clear().type(updatedName);
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Verify the update in the table
+    cy.get('[data-test=liner-type-table]')
+      .should('contain', uppercasedName);
+  });
+});
+
+

--- a/cypress/e2e/material.cy.ts
+++ b/cypress/e2e/material.cy.ts
@@ -1,0 +1,111 @@
+import { testDataGenerator } from '@test-utils/cypress/testDataGenerator';
+
+describe('Material Management', () => {
+
+  const material = testDataGenerator.Material();
+  const uppercasedMaterialId = material.materialId.toUpperCase();
+
+  beforeEach(() => {
+    cy.login();
+    // Visit the table page first
+    cy.visit('/react-ui/tables/material');
+  });
+
+  it.only('should allow creating and viewing a new die', () => {
+    // Click the create new button
+    cy.get('[data-test=create-icon-button]').click();
+
+    // Verify we're on the form page
+    cy.url().should('include', '/react-ui/forms/material');
+
+    // Fill out the form
+    cy.get('[data-test=material-form]').within(() => {
+      // Basic Information
+      cy.get('[data-test=input-name]').type(material.name);
+      cy.get('[data-test=input-materialId]').type(material.materialId);
+      cy.get('[data-test=input-width]').type(material.width.toString());
+      cy.selectRandomOptionFromDropdown('[data-test=input-vendor]');
+      cy.get('[data-test=input-locationsAsStr]').type(material.locations.join(', '));
+
+      cy.get('[data-test=input-thickness]').type(material.thickness.toString());
+      cy.get('[data-test=input-weight]').type(material.weight.toString());
+      cy.get('[data-test=input-faceColor]').type(material.faceColor);
+      cy.get('[data-test=input-adhesive]').type(material.adhesive);
+
+      cy.get('[data-test=input-freightCostPerMsi]').type(material.freightCostPerMsi);
+      cy.get('[data-test=input-costPerMsi]').type(material.costPerMsi);
+      cy.get('[data-test=input-quotePricePerMsi]').type(material.quotePricePerMsi.toString());
+
+
+      cy.get('[data-test=input-lowStockThreshold]').type(material.lowStockThreshold.toString());
+      cy.get('[data-test=input-lowStockBuffer]').type(material.lowStockBuffer.toString());
+
+      cy.get('[data-test=input-description]').type(material.description);
+      cy.get('[data-test=input-whenToUse]').type(material.whenToUse);
+      cy.get('[data-test=input-alternativeStock]').type(material.alternativeStock);
+
+      cy.get('[data-test=input-length]').type(material.length.toString());
+      cy.get('[data-test=input-facesheetWeightPerMsi]').type(material.facesheetWeightPerMsi.toString());
+      cy.get('[data-test=input-adhesiveWeightPerMsi]').type(material.adhesiveWeightPerMsi.toString());
+      cy.get('[data-test=input-linerWeightPerMsi]').type(material.linerWeightPerMsi.toString());
+      cy.get('[data-test=input-productNumber]').type(material.productNumber);
+      cy.get('[data-test=input-masterRollSize]').type(material.masterRollSize.toString());
+      cy.get('[data-test=input-image]').type(material.image);
+      cy.selectRandomOptionFromDropdown('[data-test=input-linerType]');
+      cy.selectRandomOptionFromDropdown('[data-test=input-adhesiveCategory]');
+      cy.selectRandomOptionFromDropdown('[data-test=input-materialCategory]');
+
+      cy.get('[data-test=submit-button]').click();
+    });
+
+    // Verify we're redirected back to the table
+    cy.url().should('include', '/react-ui/tables/material');
+
+    // Verify the new delivery method appears in the table
+    cy.get('[data-test=material-table]')
+      .should('exist') // waits for the table
+      .and('be.visible')
+      .should('contain', uppercasedMaterialId);
+  });
+
+  // it('should allow searching for a delivery method', () => {
+  //   // Search for the delivery method
+  //   cy.get('[data-test=searchbar]').type(material.dieNumber);
+
+  //   // Wait for the table to be ready and verify search results
+  //   cy.get('[data-test=die-table]').should('exist');
+  //   cy.get('[data-test=table-row]').should('exist');
+  //   cy.get('[data-test=die-table]')
+  //     .should('contain', uppercasedMaterialId);
+  // });
+
+  // it('should allow editing an existing die', () => {
+  //   const updatedSerialNumber = material.serialNumber + ' Updated';
+
+  //   // Find the row with our test delivery method and click the edit button
+  //   cy.get('[data-test=die-table]')
+  //     .contains(uppercasedMaterialId)
+  //     .closest('[data-test=table-row]')  // Get the row containing our text
+  //     .find('[data-test=row-actions]')  // Find the actions container
+  //     .find('[data-test=row-actions-button]')  // Find the button within actions
+  //     .click();
+
+  //   // Click the edit button in the dropdown menu
+  //   cy.get('[data-test=row-actions-menu]')
+  //     .find('[data-test=row-action-item]')
+  //     .contains('Edit')
+  //     .click();
+
+  //   // Update the form
+  //   cy.get('[data-test=die-form]').within(() => {
+  //     cy.get('[data-test=input-serialNumber]').clear().type(updatedSerialNumber);
+  //     cy.get('[data-test=submit-button]').click();
+  //   });
+
+  //   // Wait for the table to be ready and verify the update
+  //   cy.get('[data-test=die-table]').should('exist');
+  //   cy.get('[data-test=table-row]').should('exist');
+  //   cy.get('[data-test=die-table]')
+  //     .should('contain', updatedSerialNumber);
+  // });
+});

--- a/cypress/e2e/material.cy.ts
+++ b/cypress/e2e/material.cy.ts
@@ -1,7 +1,6 @@
 import { testDataGenerator } from '@test-utils/cypress/testDataGenerator';
 
 describe('Material Management', () => {
-
   const material = testDataGenerator.Material();
   const uppercasedMaterialId = material.materialId.toUpperCase();
 
@@ -11,7 +10,7 @@ describe('Material Management', () => {
     cy.visit('/react-ui/tables/material');
   });
 
-  it.only('should allow creating and viewing a new die', () => {
+  it('should allow creating and viewing a new material', () => {
     // Click the create new button
     cy.get('[data-test=create-icon-button]').click();
 
@@ -61,51 +60,51 @@ describe('Material Management', () => {
     // Verify we're redirected back to the table
     cy.url().should('include', '/react-ui/tables/material');
 
-    // Verify the new delivery method appears in the table
+    // Verify the new material appears in the table
     cy.get('[data-test=material-table]')
       .should('exist') // waits for the table
       .and('be.visible')
       .should('contain', uppercasedMaterialId);
   });
 
-  // it('should allow searching for a delivery method', () => {
-  //   // Search for the delivery method
-  //   cy.get('[data-test=searchbar]').type(material.dieNumber);
+  it('should allow searching for a material', () => {
+    // Search for the material
+    cy.get('[data-test=searchbar]').type(uppercasedMaterialId);
 
-  //   // Wait for the table to be ready and verify search results
-  //   cy.get('[data-test=die-table]').should('exist');
-  //   cy.get('[data-test=table-row]').should('exist');
-  //   cy.get('[data-test=die-table]')
-  //     .should('contain', uppercasedMaterialId);
-  // });
+    // Wait for the table to be ready and verify search results
+    cy.get('[data-test=material-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=material-table]')
+      .should('contain', uppercasedMaterialId);
+  });
 
-  // it('should allow editing an existing die', () => {
-  //   const updatedSerialNumber = material.serialNumber + ' Updated';
+  it('should allow editing an existing material', () => {
+    const updatedName = material.name + ' Updated';
 
-  //   // Find the row with our test delivery method and click the edit button
-  //   cy.get('[data-test=die-table]')
-  //     .contains(uppercasedMaterialId)
-  //     .closest('[data-test=table-row]')  // Get the row containing our text
-  //     .find('[data-test=row-actions]')  // Find the actions container
-  //     .find('[data-test=row-actions-button]')  // Find the button within actions
-  //     .click();
+    // Find the row with our test material and click the edit button
+    cy.get('[data-test=material-table]')
+      .contains(uppercasedMaterialId)
+      .closest('[data-test=table-row]')  // Get the row containing our text
+      .find('[data-test=row-actions]')  // Find the actions container
+      .find('[data-test=row-actions-button]')  // Find the button within actions
+      .click();
 
-  //   // Click the edit button in the dropdown menu
-  //   cy.get('[data-test=row-actions-menu]')
-  //     .find('[data-test=row-action-item]')
-  //     .contains('Edit')
-  //     .click();
+    // Click the edit button in the dropdown menu
+    cy.get('[data-test=row-actions-menu]')
+      .find('[data-test=row-action-item]')
+      .contains('Edit')
+      .click();
 
-  //   // Update the form
-  //   cy.get('[data-test=die-form]').within(() => {
-  //     cy.get('[data-test=input-serialNumber]').clear().type(updatedSerialNumber);
-  //     cy.get('[data-test=submit-button]').click();
-  //   });
+    // Update the form
+    cy.get('[data-test=material-form]').within(() => {
+      cy.get('[data-test=input-name]').clear().type(updatedName);
+      cy.get('[data-test=submit-button]').click();
+    });
 
-  //   // Wait for the table to be ready and verify the update
-  //   cy.get('[data-test=die-table]').should('exist');
-  //   cy.get('[data-test=table-row]').should('exist');
-  //   cy.get('[data-test=die-table]')
-  //     .should('contain', updatedSerialNumber);
-  // });
+    // Wait for the table to be ready and verify the update
+    cy.get('[data-test=material-table]').should('exist');
+    cy.get('[data-test=table-row]').should('exist');
+    cy.get('[data-test=material-table]')
+      .should('contain', updatedName.toUpperCase());
+  });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -54,18 +54,36 @@ Cypress.Commands.add('logout', () => {
 })
 
 // Custom command for selecting an option from CustomSelect
-Cypress.Commands.add('selectFromCustomSelect', (selector: string, optionText: string) => {
+Cypress.Commands.add('selectFromDropdown', (selector: string, optionText: string) => {
   cy.get(selector).click(); // Opens the dropdown
   cy.get('[data-test=select-items-dropdown]').should('be.visible');
   cy.get('[data-test=select-search-input]').type(optionText); // Type to search
   cy.get('[data-test=select-dropdown-item]').contains(optionText).click();
 });
 
+Cypress.Commands.add('selectRandomOptionFromDropdown', (selector) => {
+  // Open the dropdown
+  cy.get(selector).click();
+
+  // Get all dropdown items, excluding the first one
+  cy.get('[data-test=select-dropdown-item]').not(':first').then($items => {
+    // Get the count of the remaining items
+    const count = $items.length;
+
+    // Generate a random index
+    const randomIndex = Math.floor(Math.random() * count);
+
+    // Click on the randomly selected item
+    cy.wrap($items).eq(randomIndex).click();
+  });
+});
+
 // Add the command to the Cypress namespace
 declare global {
   namespace Cypress {
     interface Chainable {
-      selectFromCustomSelect(selector: string, optionText: string): Chainable<void>
+      selectFromDropdown(selector: string, optionText: string): Chainable<void>,
+      selectRandomOptionFromDropdown(selector: string)
     }
   }
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -53,3 +53,20 @@ Cypress.Commands.add('logout', () => {
   cy.request('/auth/logout'); /* TODO: Initiate logout via a UI button instead of direct HTTP request*/
 })
 
+// Custom command for selecting an option from CustomSelect
+Cypress.Commands.add('selectFromCustomSelect', (selector: string, optionText: string) => {
+  cy.get(selector).click(); // Opens the dropdown
+  cy.get('[data-test=select-items-dropdown]').should('be.visible');
+  cy.get('[data-test=select-search-input]').type(optionText); // Type to search
+  cy.get('[data-test=select-dropdown-item]').contains(optionText).click();
+});
+
+// Add the command to the Cypress namespace
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      selectFromCustomSelect(selector: string, optionText: string): Chainable<void>
+    }
+  }
+}
+

--- a/cypress/support/seedTestDatabase.ts
+++ b/cypress/support/seedTestDatabase.ts
@@ -1,7 +1,10 @@
 import { UserModel } from '../../application/api/models/user';
-import { TEST_USER } from './testData';
-import { clearTestDatabase } from '../../test/sharedTestDatabase';
+import { TEST_USER, VENDORS, ADHESIVE_CATEGORIES, MATERIAL_CATEGORIES, LINER_TYPES } from './testData';
 import { USER } from '../../application/api/enums/authRolesEnum';
+import { VendorModel } from '../../application/api/models/vendor';
+import { AdhesiveCategoryModel } from '../../application/api/models/adhesiveCategory';
+import { MaterialCategoryModel } from '../../application/api/models/materialCategory';
+import { LinerTypeModel } from '../../application/api/models/linerType';
 
 const TEST_API_URL = 'http://localhost:8069';
 
@@ -12,12 +15,16 @@ export async function seedTestDatabase() {
     await registerUserAndAssignAuthRole(TEST_USER, [USER]);
 
     /* [START] SEED TEST DATA */
-    /*    TODO: Seed test data here */
+    await VendorModel.insertMany(VENDORS);
+    await AdhesiveCategoryModel.insertMany(ADHESIVE_CATEGORIES);
+    await MaterialCategoryModel.insertMany(MATERIAL_CATEGORIES);
+    await LinerTypeModel.insertMany(LINER_TYPES);
     /* [END] SEED TEST DATA */
 
     console.log('Test database seeded');
 
-    const users = await UserModel.find({}).lean();  
+    const users = await UserModel.find({}).lean();
+
 
     console.log('users in cypress test database:', users);
 }

--- a/cypress/support/testData.ts
+++ b/cypress/support/testData.ts
@@ -1,3 +1,5 @@
+import { testDataGenerator } from "../../test-utils/cypress/testDataGenerator";
+
 export const TEST_USER = {
     firstName: 'Test',
     lastName: 'User',
@@ -6,3 +8,27 @@ export const TEST_USER = {
     password: 'password123',
     authRoles: ['ADMIN']
 };
+
+export const VENDORS = [
+  testDataGenerator.Vendor(),
+  testDataGenerator.Vendor(),
+  testDataGenerator.Vendor(),
+]
+
+export const LINER_TYPES = [
+  testDataGenerator.LinerType(),
+  testDataGenerator.LinerType(),
+  testDataGenerator.LinerType(),
+]
+
+export const ADHESIVE_CATEGORIES = [
+  testDataGenerator.AdhesiveCategory(),
+  testDataGenerator.AdhesiveCategory(),
+  testDataGenerator.AdhesiveCategory(),
+]
+
+export const MATERIAL_CATEGORIES = [
+  testDataGenerator.MaterialCategory(),
+  testDataGenerator.MaterialCategory(),
+  testDataGenerator.MaterialCategory(),
+]

--- a/test-utils/testDataGenerator.ts
+++ b/test-utils/testDataGenerator.ts
@@ -11,6 +11,7 @@ import { unwindDirections } from '../application/api/enums/unwindDirectionsEnum'
 import { finishTypes } from '../application/api/enums/finishTypesEnum';
 import { AVAILABLE_AUTH_ROLES } from '../application/api/enums/authRolesEnum';
 import { ovOrEpmOptions } from '../application/api/enums/ovOrEpmEnum';
+import { DIE_NUMBER_PREFIXES } from '../application/api/enums/dieNumberPrefixEnum';
 
 export const mockData = {
     Die: getDie,
@@ -31,7 +32,7 @@ function getDie() {
         shape: chance.pickone(dieShapes),
         sizeAcross: chance.floating({ min: 0.01, max: 10, fixed: 2 }),
         sizeAround: chance.floating({ min: 0.01, max: 10, fixed: 2 }),
-        dieNumber: 'DC-1234',
+        dieNumber: `${chance.pickone(DIE_NUMBER_PREFIXES)}-${chance.integer({ min: 1000, max: 9999 })}`,
         numberAcross: chance.d10(),
         numberAround: chance.d10(),
         gear: chance.d100(),

--- a/test-utils/testDataGenerator.ts
+++ b/test-utils/testDataGenerator.ts
@@ -25,7 +25,9 @@ export const mockData = {
     CreditTerm: getCreditTerm,
     AdhesiveCategory: getAdhesiveCategory,
     DeliveryMethod: getDeliveryMethod,
-    LinerType: getLinerType
+    LinerType: getLinerType,
+    Vendor: getVendor,
+    MaterialCategory: getMaterialCategory
 };
 
 function getDie() {
@@ -57,6 +59,21 @@ function getDie() {
     };
 }
 
+function getVendor() {
+    return {
+      name: chance.string(),
+      phoneNumber: chance.phone(),
+      email: chance.email(),
+      notes: chance.paragraph(),
+      website: chance.url(),
+      primaryContactName: chance.string(),
+      primaryContactPhoneNumber: chance.phone(),
+      primaryContactEmail: chance.email(),
+      primaryAddress: getAddress(),
+      remittanceAddress: chance.pickone([getAddress(), undefined])
+    };
+}
+
 function getLinerType() {
     return {
         name: chance.string()
@@ -70,6 +87,12 @@ function getCreditTerm() {
 }
 
 function getAdhesiveCategory() {
+    return {
+        name: chance.string()
+    };
+}
+
+function getMaterialCategory() {
     return {
         name: chance.string()
     };

--- a/test-utils/testDataGenerator.ts
+++ b/test-utils/testDataGenerator.ts
@@ -22,7 +22,8 @@ export const mockData = {
     BaseProduct: getBaseProduct,
     Address: getAddress,
     CreditTerm: getCreditTerm,
-    AdhesiveCategory: getAdhesiveCategory
+    AdhesiveCategory: getAdhesiveCategory,
+    DeliveryMethod: getDeliveryMethod
 };
 
 function getDie() {
@@ -172,5 +173,11 @@ function getAddress() {
         city: chance.city(),
         state: chance.state(),
         zipCode: chance.zip()
+    };
+}
+
+function getDeliveryMethod() {
+    return {
+        name: chance.string()
     };
 }

--- a/test-utils/testDataGenerator.ts
+++ b/test-utils/testDataGenerator.ts
@@ -24,7 +24,8 @@ export const mockData = {
     Address: getAddress,
     CreditTerm: getCreditTerm,
     AdhesiveCategory: getAdhesiveCategory,
-    DeliveryMethod: getDeliveryMethod
+    DeliveryMethod: getDeliveryMethod,
+    LinerType: getLinerType
 };
 
 function getDie() {
@@ -53,6 +54,12 @@ function getDie() {
         status: chance.pickone(dieStatuses),
         quantity: chance.d100(),
         isLamination: chance.pickone([chance.bool(), undefined])
+    };
+}
+
+function getLinerType() {
+    return {
+        name: chance.string()
     };
 }
 

--- a/test/models/vendor.spec.js
+++ b/test/models/vendor.spec.js
@@ -12,18 +12,7 @@ describe('validation', () => {
     beforeEach(() => {
         jest.resetAllMocks();
 
-        vendorAttributes = {
-            name: chance.string(),
-            phoneNumber: chance.phone(),
-            email: chance.email(),
-            notes: chance.paragraph(),
-            website: chance.url(),
-            primaryContactName: chance.string(),
-            primaryContactPhoneNumber: chance.phone(),
-            primaryContactEmail: chance.email(),
-            primaryAddress: testDataGenerator.mockData.Address(),
-            remittanceAddress: chance.pickone([testDataGenerator.mockData.Address(), undefined])
-        };
+        vendorAttributes = testDataGenerator.mockData.Vendor();
     });
 
     it('should validate when required attributes are defined', () => {

--- a/test/sharedTestDatabase.ts
+++ b/test/sharedTestDatabase.ts
@@ -76,7 +76,7 @@ export async function clearTestDatabase() {
   console.log('Test database cleared');
 }
 
-function removeTestDbUriFile() {
+export function removeTestDbUriFile() {
   if (fs.existsSync(TEST_DB_URI_FILE)) {
     fs.unlinkSync(TEST_DB_URI_FILE);
   }


### PR DESCRIPTION
#  Description

This PR builds onto the initiative started a PR or so ago, where all the old cypress tests were ripped out, and we're re-buildling them all using an in-memory database, and better technique.

This PR adds cypress tests for the following:
  1. DeliveryMethod
  2. Die
  3. LinerType
  4. Material

I also came across many areas of improvement/refactoring while adding these tests. That will likely continue until we're done with these tests. Then I'll come back thru and refactor everyone again. We're on our way 🎊 