### PR TITLE
Setup Soft-Deletes on all Documents

### DIFF
--- a/application/_types/express.d.ts
+++ b/application/_types/express.d.ts
@@ -1,0 +1,9 @@
+import { TokenPayload } from '../api/middleware/authorize';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user: TokenPayload;
+    }
+  }
+} 

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -21,7 +21,7 @@ export interface ILinerType extends SchemaTimestampsConfig, Document<MongooseId>
   name: string;
 }
 
-export interface ICreditTerm extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface ICreditTerm extends SchemaTimestampsConfig, SoftDeleteDocument {
   description: string;
 }
 

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -57,7 +57,7 @@ export interface IMaterialLengthAdjustment extends SchemaTimestampsConfig, Docum
   notes?: string;
 }
 
-export interface IMaterial extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface IMaterial extends SchemaTimestampsConfig, SoftDeleteDocument {
   name: string;
   materialId: string;
   vendor: MongooseId | IVendor;

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -17,7 +17,7 @@ export interface IAdhesiveCategory extends SchemaTimestampsConfig, SoftDeleteDoc
   name: string;
 }
 
-export interface ILinerType extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface ILinerType extends SchemaTimestampsConfig, SoftDeleteDocument {
   name: string;
 }
 

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -51,7 +51,7 @@ export interface IVendor extends SchemaTimestampsConfig, Document<MongooseId>  {
   mfgSpecNumber?: string;
 }
 
-export interface IMaterialLengthAdjustment extends SchemaTimestampsConfig, Document<MongooseId>  {
+export interface IMaterialLengthAdjustment extends SchemaTimestampsConfig, SoftDeleteDocument {
   material: MongooseId | IMaterial;
   length: number;
   notes?: string;

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -25,7 +25,7 @@ export interface ICreditTerm extends SchemaTimestampsConfig, SoftDeleteDocument 
   description: string;
 }
 
-export interface ICustomer extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface ICustomer extends SchemaTimestampsConfig, SoftDeleteDocument {
   customerId: string;
   name: string;
   notes?: string;

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -3,6 +3,7 @@ import { SchemaTimestampsConfig } from "mongoose";
 import { IAddress, IContact, IShippingLocation } from "./schemas.ts";
 import { MongooseId, MongooseIdStr } from "./typeAliases.ts";
 import { AuthRoles } from "@shared/enums/auth.ts";
+import { SoftDeleteDocument } from 'mongoose-delete';
 
 export interface IDeliveryMethod extends SchemaTimestampsConfig, Document<MongooseId> {
   name: string;
@@ -12,7 +13,7 @@ export interface IMaterialCategory extends SchemaTimestampsConfig, Document<Mong
   name: string;
 }
 
-export interface IAdhesiveCategory extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface IAdhesiveCategory extends SchemaTimestampsConfig, SoftDeleteDocument {
   name: string;
 }
 

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -96,7 +96,7 @@ export interface IMaterial extends SchemaTimestampsConfig, Document<MongooseId> 
   netLength: number;
 }
 
-export interface IDie extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface IDie extends SchemaTimestampsConfig, SoftDeleteDocument {
   dieNumber: string,
   shape: string,
   sizeAcross: number,

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -5,27 +5,27 @@ import { MongooseId, MongooseIdStr } from "./typeAliases.ts";
 import { AuthRoles } from "@shared/enums/auth.ts";
 import { SoftDeleteDocument } from 'mongoose-delete';
 
-export interface IDeliveryMethod extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type IDeliveryMethod = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   name: string;
 }
 
-export interface IMaterialCategory extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type IMaterialCategory = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   name: string;
 }
 
-export interface IAdhesiveCategory extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type IAdhesiveCategory = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   name: string;
 }
 
-export interface ILinerType extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type ILinerType = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   name: string;
 }
 
-export interface ICreditTerm extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type ICreditTerm = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   description: string;
 }
 
-export interface ICustomer extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type ICustomer = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   customerId: string;
   name: string;
   notes?: string;
@@ -51,13 +51,13 @@ export type IVendor = SchemaTimestampsConfig & Document<MongooseId> & SoftDelete
   mfgSpecNumber?: string;
 }
 
-export interface IMaterialLengthAdjustment extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type IMaterialLengthAdjustment = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   material: MongooseId | IMaterial;
   length: number;
   notes?: string;
 }
 
-export interface IMaterial extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type IMaterial = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   name: string;
   materialId: string;
   vendor: MongooseId | IVendor;
@@ -96,7 +96,7 @@ export interface IMaterial extends SchemaTimestampsConfig, SoftDeleteDocument {
   netLength: number;
 }
 
-export interface IDie extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type IDie = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   dieNumber: string,
   shape: string,
   sizeAcross: number,
@@ -125,7 +125,7 @@ export interface IDie extends SchemaTimestampsConfig, SoftDeleteDocument {
   isLamination?: boolean
 }
 
-export interface IMaterialOrder extends SchemaTimestampsConfig, SoftDeleteDocument {
+export type IMaterialOrder = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   author: MongooseId | IUser;
   material: MongooseId | IMaterial;
   purchaseOrderNumber: string;

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -5,7 +5,7 @@ import { MongooseId, MongooseIdStr } from "./typeAliases.ts";
 import { AuthRoles } from "@shared/enums/auth.ts";
 import { SoftDeleteDocument } from 'mongoose-delete';
 
-export interface IDeliveryMethod extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface IDeliveryMethod extends SchemaTimestampsConfig, SoftDeleteDocument {
   name: string;
 }
 

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -125,7 +125,7 @@ export interface IDie extends SchemaTimestampsConfig, SoftDeleteDocument {
   isLamination?: boolean
 }
 
-export interface IMaterialOrder extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface IMaterialOrder extends SchemaTimestampsConfig, SoftDeleteDocument {
   author: MongooseId | IUser;
   material: MongooseId | IMaterial;
   purchaseOrderNumber: string;

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -9,7 +9,7 @@ export interface IDeliveryMethod extends SchemaTimestampsConfig, SoftDeleteDocum
   name: string;
 }
 
-export interface IMaterialCategory extends SchemaTimestampsConfig, Document<MongooseId> {
+export interface IMaterialCategory extends SchemaTimestampsConfig, SoftDeleteDocument {
   name: string;
 }
 

--- a/application/_types/shared/models.ts
+++ b/application/_types/shared/models.ts
@@ -37,7 +37,7 @@ export interface ICustomer extends SchemaTimestampsConfig, SoftDeleteDocument {
   overun: number;
 }
 
-export interface IVendor extends SchemaTimestampsConfig, Document<MongooseId>  {
+export type IVendor = SchemaTimestampsConfig & Document<MongooseId> & SoftDeleteDocument & {
   name: string;
   phoneNumber?: string;
   email?: string;

--- a/application/api/controllers/adhesiveCategoryController.ts
+++ b/application/api/controllers/adhesiveCategoryController.ts
@@ -74,7 +74,7 @@ router.get('/search', async (request: Request<{}, {}, {}, SearchQuery>, response
 
 router.delete('/:mongooseId', async (request, response) => {
     try {
-        const deletedAdhesiveCategory = await AdhesiveCategoryModel.findByIdAndDelete(request.params.mongooseId).exec();
+        const deletedAdhesiveCategory = await AdhesiveCategoryModel.deleteById(request.params.mongooseId)
     
         return response.status(SUCCESS).json(deletedAdhesiveCategory);
     } catch (error) {

--- a/application/api/controllers/adhesiveCategoryController.ts
+++ b/application/api/controllers/adhesiveCategoryController.ts
@@ -74,7 +74,7 @@ router.get('/search', async (request: Request<{}, {}, {}, SearchQuery>, response
 
 router.delete('/:mongooseId', async (request, response) => {
     try {
-        const deletedAdhesiveCategory = await AdhesiveCategoryModel.deleteById(request.params.mongooseId)
+        const deletedAdhesiveCategory = await AdhesiveCategoryModel.deleteById(request.params.mongooseId, request.user._id)
     
         return response.status(SUCCESS).json(deletedAdhesiveCategory);
     } catch (error) {

--- a/application/api/controllers/creditTermsController.ts
+++ b/application/api/controllers/creditTermsController.ts
@@ -87,7 +87,7 @@ router.post('/', async (request, response) => {
 
 router.delete('/:mongooseId', async (request, response) => {
     try { 
-        const deletedCreditTerm = await CreditTermModel.findByIdAndDelete(request.params.mongooseId).exec();
+        const deletedCreditTerm = await CreditTermModel.deleteById(request.params.mongooseId, request.user._id)
 
         return response.status(SUCCESS).json(deletedCreditTerm);
     } catch (error) {

--- a/application/api/controllers/customerController.ts
+++ b/application/api/controllers/customerController.ts
@@ -104,7 +104,7 @@ router.get('/', async (_, response) => {
 
 router.delete('/:mongooseId', async (request, response) => {
   try {
-    const customer = await CustomerModel.findByIdAndDelete(request.params.mongooseId).exec();
+    const customer = await CustomerModel.deleteById(request.params.mongooseId, request.user._id)
 
     return response.status(SUCCESS).json(customer);
   } catch (error) {

--- a/application/api/controllers/deliveryMethodController.ts
+++ b/application/api/controllers/deliveryMethodController.ts
@@ -50,7 +50,7 @@ router.post('/', async (request, response) => {
 
 router.delete('/:mongooseId', async (request, response) => {
     try {
-        const deletedDeliveryMethod = await DeliveryMethodModel.findByIdAndDelete(request.params.mongooseId).exec();
+        const deletedDeliveryMethod = await DeliveryMethodModel.deleteById(request.params.mongooseId, request.user._id)
         
         return response.status(SUCCESS).json(deletedDeliveryMethod);
     } catch (error) {

--- a/application/api/controllers/dieController.ts
+++ b/application/api/controllers/dieController.ts
@@ -40,9 +40,7 @@ router.patch('/:mongooseId', async (request: Request, response: Response) => {
 
 router.delete('/:mongooseId', async (request: Request, response: Response) => {
   try {
-    const deletedDie = await DieModel.findByIdAndDelete(request.params.mongooseId)
-      .orFail(new Error(`Die not found using ID '${request.params.mongooseId}'`))
-      .exec();
+    const deletedDie = await DieModel.deleteById(request.params.mongooseId, request.user._id)
 
     return response.status(SUCCESS).json(deletedDie);
   } catch (error) {

--- a/application/api/controllers/linerTypeController.ts
+++ b/application/api/controllers/linerTypeController.ts
@@ -74,7 +74,7 @@ router.get('/search', async (request: Request<{}, {}, {}, SearchQuery>, response
 
 router.delete('/:mongooseId', async (request, response) => {
     try {
-        const deletedLinerType = await LinerTypeModel.findByIdAndDelete(request.params.mongooseId).exec();
+        const deletedLinerType = await LinerTypeModel.deleteById(request.params.mongooseId, request.user._id)
 
         return response.status(SUCCESS).json(deletedLinerType);
     } catch (error) {

--- a/application/api/controllers/materialCategoryController.ts
+++ b/application/api/controllers/materialCategoryController.ts
@@ -136,7 +136,7 @@ router.delete('/:mongooseId', async (request, response) => {
   const { mongooseId } = request.params;
 
   try {
-    await MaterialCategoryModel.findByIdAndDelete(mongooseId);
+    await MaterialCategoryModel.deleteById(mongooseId, request.user._id);
 
     return response.sendStatus(SUCCESS);
   } catch (error) {

--- a/application/api/controllers/materialController.ts
+++ b/application/api/controllers/materialController.ts
@@ -142,7 +142,7 @@ router.get('/search', async (request: Request<{}, {}, {}, SearchQuery>, response
 
 router.delete('/:mongooseId', async (request, response) => {
   try {
-    const deletedMaterial = await MaterialModel.findByIdAndDelete(request.params.mongooseId).exec();
+    const deletedMaterial = await MaterialModel.deleteById(request.params.mongooseId, request.user._id)
 
     return response.status(SUCCESS).json(deletedMaterial);
   } catch (error) {

--- a/application/api/controllers/materialLengthAdjustmentController.ts
+++ b/application/api/controllers/materialLengthAdjustmentController.ts
@@ -164,7 +164,7 @@ router.patch('/:mongooseId', async (request: Request, response: Response) => {
 
 router.delete('/:mongooseId', async (request: Request, response: Response) => {
   try { 
-      const deletedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.findByIdAndDelete(request.params.mongooseId).exec();
+      const deletedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.deleteById(request.params.mongooseId, request.user._id);
 
       return response.status(SUCCESS).json(deletedMaterialLengthAdjustment);
   } catch (error) {

--- a/application/api/controllers/materialOrdersController.ts
+++ b/application/api/controllers/materialOrdersController.ts
@@ -114,7 +114,8 @@ router.get('/search', async (request: Request<{}, {}, {}, SearchQuery>, response
 
 router.delete('/:mongooseId', async (request, response) => {
     try {
-        const deletedMaterialOrder = await MaterialOrderModel.findByIdAndDelete(request.params.mongooseId).exec();
+        const deletedMaterialOrder = await MaterialOrderModel.deleteById(request.params.mongooseId, request.user._id);
+
         return response.status(SUCCESS).json(deletedMaterialOrder);
     } catch (error) {
         console.error('Failed to delete materialOrder: ', error);

--- a/application/api/controllers/vendorController.ts
+++ b/application/api/controllers/vendorController.ts
@@ -108,9 +108,9 @@ router.patch('/:mongooseId', async (request, response) => {
 
 router.delete('/:mongooseId', async (request, response) => {
     try {
-        const deletedAdhesiveCategory = await VendorModel.findByIdAndDelete(request.params.mongooseId).exec();
+        const deletedVendor = await VendorModel.deleteById(request.params.mongooseId, request.user._id).exec();
     
-        return response.status(SUCCESS).json(deletedAdhesiveCategory);
+        return response.status(SUCCESS).json(deletedVendor);
     } catch (error) {
         console.error('Failed to delete vendor: ', error);
 

--- a/application/api/middleware/authorize.ts
+++ b/application/api/middleware/authorize.ts
@@ -36,7 +36,6 @@ export function verifyBearerToken(request: Request, response: Response, next) {
     return response.sendStatus(UNAUTHORIZED);
   }
   try {
-    /* @ts-ignore: TODO: Add request.user type via a .d.ts file */
     request.user = decodeAuthHeader(authorizationHeader)
     return next();
   } catch (error) {

--- a/application/api/models/adhesiveCategory.ts
+++ b/application/api/models/adhesiveCategory.ts
@@ -2,6 +2,7 @@ import { IAdhesiveCategory } from '@shared/types/models.ts';
 import mongoose from 'mongoose';
 import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
 
+/* Trim all strings and enable soft deletes */
 mongoose.Schema.Types.String.set('trim', true);
 mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 

--- a/application/api/models/adhesiveCategory.ts
+++ b/application/api/models/adhesiveCategory.ts
@@ -1,18 +1,26 @@
 import { IAdhesiveCategory } from '@shared/types/models.ts';
 import mongoose from 'mongoose';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
+
 mongoose.Schema.Types.String.set('trim', true);
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
+
 const Schema = mongoose.Schema;
-import mongooseDelete from 'mongoose-delete';
-mongoose.plugin(mongooseDelete, { overrideMethods: true });
 
 const schema = new Schema<IAdhesiveCategory>({
     name: {
       type: String,
       required: true,
       uppercase: true,
-      unique: true,
-      index: true
     },
 }, { timestamps: true, strict: 'throw' });
 
-export const AdhesiveCategoryModel = mongoose.model<IAdhesiveCategory>('AdhesiveCategory', schema);
+schema.index(
+  { name: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deleted: { $eq: false } }
+  }
+);
+
+export const AdhesiveCategoryModel = mongoose.model<IAdhesiveCategory, SoftDeleteModel<IAdhesiveCategory>>('AdhesiveCategory', schema);

--- a/application/api/models/creditTerm.ts
+++ b/application/api/models/creditTerm.ts
@@ -2,6 +2,7 @@ import { ICreditTerm } from '@shared/types/models.ts';
 import mongoose, { Schema } from 'mongoose';
 import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
 
+/* Trim all strings and enable soft deletes */
 mongoose.Schema.Types.String.set('trim', true);
 mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 
@@ -12,9 +13,6 @@ const schema = new Schema<ICreditTerm>({
         uppercase: true
     },
 }, { timestamps: true, strict: 'throw' });
-
-/* Text search index */
-schema.index({ description: 'text' });
 
 /* Unique index */
 schema.index(

--- a/application/api/models/creditTerm.ts
+++ b/application/api/models/creditTerm.ts
@@ -1,20 +1,28 @@
 import { ICreditTerm } from '@shared/types/models.ts';
-import mongoose from 'mongoose';
+import mongoose, { Schema } from 'mongoose';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
+
 mongoose.Schema.Types.String.set('trim', true);
-import mongooseDelete from 'mongoose-delete';
-mongoose.plugin(mongooseDelete, { overrideMethods: true });
-const Schema = mongoose.Schema;
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 
 const schema = new Schema<ICreditTerm>({
     description: {
         type: String,
         required: true,
-        uppercase: true,
-        unique: true,
-        index: true
+        uppercase: true
     },
 }, { timestamps: true, strict: 'throw' });
 
+/* Text search index */
 schema.index({ description: 'text' });
 
-export const CreditTermModel = mongoose.model<ICreditTerm>('CreditTerm', schema);
+/* Unique index */
+schema.index(
+  { description: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deleted: { $eq: false } }
+  }
+);
+
+export const CreditTermModel = mongoose.model<ICreditTerm, SoftDeleteModel<ICreditTerm>>('CreditTerm', schema);

--- a/application/api/models/customer.ts
+++ b/application/api/models/customer.ts
@@ -1,67 +1,74 @@
-import mongoose from 'mongoose';
-mongoose.Schema.Types.String.set('trim', true);
-const Schema = mongoose.Schema;
+import mongoose, { Schema } from 'mongoose';
+import { ICustomer } from '@shared/types/models.ts';
 import { addressSchema } from '../schemas/address.ts';
 import { contactSchema } from '../schemas/contact.ts';
-import mongooseDelete from 'mongoose-delete';
-import { ICustomer } from '@shared/types/models.ts';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
 
-mongoose.plugin(mongooseDelete, { overrideMethods: true });
+/* Trim all strings and enable soft deletes */
+mongoose.Schema.Types.String.set('trim', true);
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 
 function doesArrayContainElements(value) {
-    return value.length > 0;
+  return value.length > 0;
 }
 
 // ShippingLocations inherit the attributes from the address schema and add additional properties.
 // To learn more, read about "discriminators" here: https://mongoosejs.com/docs/discriminators.html
 const shippingLocationsSchema = new mongoose.Schema({
-    ...addressSchema.obj,
-    freightAccountNumber: {
-        type: String,
-        uppercase: true
-    },
-    deliveryMethod: {
-        type: Schema.Types.ObjectId,
-        ref: 'DeliveryMethod'
-    }
-}, { timestamps: true });
-
-const schema = new Schema<ICustomer>({
-    customerId: {
-        type: String,
-        required: true,
-        uppercase: true,
-        unique: true,
-        index: true
-    },
-    name: {
-        type: String,
-        required: true,
-    },
-    notes: {
-        type: String
-    },
-    businessLocations: {
-        type: [addressSchema]
-    },
-    shippingLocations: {
-        type: [shippingLocationsSchema]
-    },
-    billingLocations: {
-        type: [addressSchema]
-    },
-    contacts: {
-        type: [contactSchema],
-        validate: [doesArrayContainElements, 'Must have at least one contact']
-    },
-    creditTerms: {
-        type: [Schema.Types.ObjectId],
-        ref: 'CreditTerm'
-    },
-    overun: {
-        type: Number,
-        required: true
-    }
+  ...addressSchema.obj,
+  freightAccountNumber: {
+    type: String,
+    uppercase: true
+  },
+  deliveryMethod: {
+    type: Schema.Types.ObjectId,
+    ref: 'DeliveryMethod'
+  }
 }, { timestamps: true, strict: 'throw' });
 
-export const CustomerModel = mongoose.model<ICustomer>('Customer', schema);
+const schema = new Schema<ICustomer>({
+  customerId: {
+    type: String,
+    required: true,
+    uppercase: true
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  notes: {
+    type: String
+  },
+  businessLocations: {
+    type: [addressSchema]
+  },
+  shippingLocations: {
+    type: [shippingLocationsSchema]
+  },
+  billingLocations: {
+    type: [addressSchema]
+  },
+  contacts: {
+    type: [contactSchema],
+    validate: [doesArrayContainElements, 'Must have at least one contact']
+  },
+  creditTerms: {
+    type: [Schema.Types.ObjectId],
+    ref: 'CreditTerm'
+  },
+  overun: {
+    type: Number,
+    required: true
+  }
+}, { timestamps: true, strict: 'throw' });
+
+/* Unique index */
+schema.index(
+  { customerId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deleted: { $eq: false } }
+  }
+)
+
+export const CustomerModel = mongoose.model<ICustomer, SoftDeleteModel<ICustomer>>('Customer', schema);

--- a/application/api/models/deliveryMethod.ts
+++ b/application/api/models/deliveryMethod.ts
@@ -1,19 +1,27 @@
-import mongoose from 'mongoose';
+import { IDeliveryMethod } from '@shared/types/models';
+import mongoose, { Schema } from 'mongoose';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
+
+/* Trim all strings and enable soft deletes */
 mongoose.Schema.Types.String.set('trim', true);
-const Schema = mongoose.Schema;
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 
-import mongooseDelete from 'mongoose-delete';
-mongoose.plugin(mongooseDelete, { overrideMethods: true });
-
-const deliveryMethodSchema = new Schema({
+const schema = new Schema<IDeliveryMethod>({
     name: {
         type: String,
         required: true,
-        uppercase: true,
-        unique: true,
-        index: true
+        uppercase: true
     }
-}, { timestamps: true });
+}, { timestamps: true, strict: 'throw' });
 
-export const DeliveryMethodModel = mongoose.model('DeliveryMethod', deliveryMethodSchema);
+/* Unique index */
+schema.index(
+  { name: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deleted: { $eq: false } }
+  }
+);
+
+export const DeliveryMethodModel = mongoose.model<IDeliveryMethod, SoftDeleteModel<IDeliveryMethod>>('DeliveryMethod', schema);
 

--- a/application/api/models/linerType.ts
+++ b/application/api/models/linerType.ts
@@ -1,21 +1,29 @@
 import { ILinerType } from '@shared/types/models.ts';
-import mongoose from 'mongoose';
+import mongoose, { Schema } from 'mongoose';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
+
+/* Trim all strings and enable soft deletes */
 mongoose.Schema.Types.String.set('trim', true);
-const Schema = mongoose.Schema;
-import mongoose_delete from 'mongoose-delete';
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 
 const schema = new Schema<ILinerType>({
     name: {
         type: String,
         required: true,
-        uppercase: true,
-        unique: true
+        uppercase: true
     }
 }, { 
     timestamps: true,
     strict: 'throw'
 });
 
-schema.plugin(mongoose_delete, { overrideMethods: true });
+/* Unique index */
+schema.index(
+  { name: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deleted: { $eq: false } }
+  }
+);
 
-export const LinerTypeModel = mongoose.model<ILinerType>('LinerType', schema);
+export const LinerTypeModel = mongoose.model<ILinerType, SoftDeleteModel<ILinerType>>('LinerType', schema);

--- a/application/api/models/material.ts
+++ b/application/api/models/material.ts
@@ -237,8 +237,8 @@ schema.index(
   }
 );
 
-export const MaterialModel = mongoose.model<IMaterial, SoftDeleteModel<IMaterial>>('Material', schema);
-
-
 /* Hooks */
 schema.post(MongooseHooks.Save, (doc: IMaterial) => populateMaterialInventories([doc._id.toString()]))
+
+/* Model */
+export const MaterialModel = mongoose.model<IMaterial, SoftDeleteModel<IMaterial>>('Material', schema);

--- a/application/api/models/materialCategory.ts
+++ b/application/api/models/materialCategory.ts
@@ -1,9 +1,10 @@
 import { IMaterialCategory } from '@shared/types/models.ts';
-import mongoose from 'mongoose';
+import mongoose, { Schema } from 'mongoose';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
+
+/* Trim all strings and enable soft deletes */
 mongoose.Schema.Types.String.set('trim', true);
-const Schema = mongoose.Schema;
-import mongoose_delete from 'mongoose-delete';
-mongoose.plugin(mongoose_delete, { overrideMethods: true });
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 
 const schema = new Schema<IMaterialCategory>({
     name: {
@@ -13,5 +14,12 @@ const schema = new Schema<IMaterialCategory>({
     }
 }, { timestamps: true, strict: 'throw' });
 
+schema.index(
+  { name: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deleted: { $eq: false } }
+  }
+);
 
-export const MaterialCategoryModel = mongoose.model<IMaterialCategory>('MaterialCategory', schema);
+export const MaterialCategoryModel = mongoose.model<IMaterialCategory, SoftDeleteModel<IMaterialCategory>>('MaterialCategory', schema);

--- a/application/api/models/materialLengthAdjustment.ts
+++ b/application/api/models/materialLengthAdjustment.ts
@@ -32,11 +32,10 @@ const schema = new Schema<IMaterialLengthAdjustment>({
 
 /* Hooks */
 schema.post([...createAndUpdateOneHooks, ...updateManyHooks], (result: IMaterialLengthAdjustment | IMaterialLengthAdjustment[]) => {
-  if (result instanceof Array) {
-    const materialIds = result.map(({material}) => material && material.toString());
-    populateMaterialInventories(materialIds);
-  } else {
+  if ('material' in result) {
     populateMaterialInventories([result.material && result.material.toString()]);
+  } else {
+    populateMaterialInventories();
   }
 })
 

--- a/application/api/models/materialLengthAdjustment.ts
+++ b/application/api/models/materialLengthAdjustment.ts
@@ -1,10 +1,12 @@
 import { IMaterialLengthAdjustment } from '@shared/types/models.ts';
-import mongoose from 'mongoose';
-mongoose.Schema.Types.String.set('trim', true);
-const Schema = mongoose.Schema;
-import mongoose_delete from 'mongoose-delete';
+import mongoose, { Schema } from 'mongoose';
 import { createAndUpdateOneHooks, deleteManyHooks, deleteOneHooks, MongooseHooks, updateManyHooks } from '../constants/mongoose.ts';
 import { populateMaterialInventories } from '../services/materialInventoryService.ts';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
+
+/* Trim all strings and enable soft deletes */
+mongoose.Schema.Types.String.set('trim', true);
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
 
 /* 
   * This table is responsible for Adding or Subtracting material from Inventory.
@@ -27,13 +29,8 @@ const schema = new Schema<IMaterialLengthAdjustment>({
     }
 }, { timestamps: true, strict: 'throw' });
 
-schema.plugin(mongoose_delete, {overrideMethods: true});
 
-schema.index({ 
-  'material.name': 'text', 
-  'material.materialId': 'text' 
-});
-
+/* Hooks */
 schema.post([...createAndUpdateOneHooks, ...updateManyHooks], (result: IMaterialLengthAdjustment | IMaterialLengthAdjustment[]) => {
   if (result instanceof Array) {
     const materialIds = result.map(({material}) => material && material.toString());
@@ -49,4 +46,7 @@ schema.post(MongooseHooks.BulkWrite, () => populateMaterialInventories())
 
 schema.post([...deleteOneHooks, ...deleteManyHooks], (_) => populateMaterialInventories())
 
-export const MaterialLengthAdjustmentModel = mongoose.model<IMaterialLengthAdjustment>('MaterialLengthAdjustment', schema);
+
+/* Model */
+export const MaterialLengthAdjustmentModel = mongoose.model<IMaterialLengthAdjustment, SoftDeleteModel<IMaterialLengthAdjustment>>('MaterialLengthAdjustment', schema);
+

--- a/application/api/models/materialOrder.ts
+++ b/application/api/models/materialOrder.ts
@@ -1,9 +1,14 @@
-import mongoose from 'mongoose';
+import mongoose, { UpdateWriteOpResult } from 'mongoose';
+import MongooseDelete, { SoftDeleteModel } from 'mongoose-delete';
 import { convertDollarsToPennies, convertPenniesToDollars, PENNIES_PER_DOLLAR } from '../services/currencyService.ts';
 import { createAndUpdateOneHooks, deleteManyHooks, deleteOneHooks, MongooseHooks, updateManyHooks } from '../constants/mongoose.ts';
 import { IMaterialOrder } from '@shared/types/models.ts';
 import { populateMaterialInventories } from '../services/materialInventoryService.ts';
+
+/* Trim all strings and enable soft deletes */
 mongoose.Schema.Types.String.set('trim', true);
+mongoose.plugin(MongooseDelete, { overrideMethods: true, deletedBy: true, deletedAt: true });
+
 const Schema = mongoose.Schema;
 
 const TOTAL_ROLLS_MIN = 1;
@@ -14,106 +19,120 @@ const TOTAL_COST_MAX = 500000;
 
 const ONLY_NUMBERS_REGEX = /^[0-9]*$/;
 
-const validatePurchaseOrderNumber = function(text) {
-    if (!text) {
-        return false;
-    }
-    return ONLY_NUMBERS_REGEX.test(text);
+const validatePurchaseOrderNumber = function (text) {
+  if (!text) {
+    return false;
+  }
+  return ONLY_NUMBERS_REGEX.test(text);
 };
 
 const schema = new Schema({
-    author: {
-        type: Schema.Types.ObjectId,
-        ref: 'User',
-        required: [true, 'AUTHOR could not be determined']
-    },
-    material: {
-        type: Schema.Types.ObjectId,
-        ref: 'Material',
-        required: true
-    },
-    purchaseOrderNumber: {
-        type: String,
-        required: [true, 'P.O. NUMBER is required'],
-        validate : {
-            validator : validatePurchaseOrderNumber,
-            message   : 'P.O Number must ONLY contain numbers'
-        }
-    },
-    orderDate: {
-        type: Date,
-        required: [true, 'ORDER DATE is required'],
-    },
-    arrivalDate: {
-        type: Date,
-        required: [true, 'ARRIVAL DATE is required'],
-    },
-    feetPerRoll: {
-        type: Number,
-        required: [true, 'FEET PER ROLL is required'],
-        min: 0
-    },
-    totalRolls: {
-        type: Number,
-        required: [true, 'TOTAL ROLLS is required'],
-        min: [TOTAL_ROLLS_MIN, 'Total Rolls cannot be less than 1'],
-        max: [TOTAL_ROLLS_MAX, 'Total Rolls cannot be greater than 100'],
-        validate : {
-            validator : Number.isInteger,
-            message   : '{VALUE} is not an integer'
-        }
-    },
-    totalCost: {
-        type: Number,
-        required: [true, 'TOTAL COST is required'],
-        min: [TOTAL_COST_MIN * PENNIES_PER_DOLLAR, 'Total Cost must be more than $1'],
-        max: [TOTAL_COST_MAX * PENNIES_PER_DOLLAR, 'Total Cost must be less than $500,000'],
-        get: convertPenniesToDollars,
-        set: convertDollarsToPennies,
-    },
-    vendor: {
-        type: Schema.Types.ObjectId,
-        ref: 'Vendor',
-        required: [true, 'VENDOR is required'],
-    },
-    hasArrived: {
-        type: Boolean,
-        required: false
-    },
-    notes: {
-        type: String,
-        required: false
-    },
-    freightCharge: {
-        type: Number,
-        required: true,
-        get: convertPenniesToDollars,
-        set: convertDollarsToPennies,
-        min: 0
-    },
-    fuelCharge: {
-        type: Number,
-        required: true,
-        get: convertPenniesToDollars,
-        set: convertDollarsToPennies,
-        min: 0
+  author: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: [true, 'AUTHOR could not be determined']
+  },
+  material: {
+    type: Schema.Types.ObjectId,
+    ref: 'Material',
+    required: true
+  },
+  purchaseOrderNumber: {
+    type: String,
+    required: [true, 'P.O. NUMBER is required'],
+    validate: {
+      validator: validatePurchaseOrderNumber,
+      message: 'P.O Number must ONLY contain numbers'
     }
+  },
+  orderDate: {
+    type: Date,
+    required: [true, 'ORDER DATE is required'],
+  },
+  arrivalDate: {
+    type: Date,
+    required: [true, 'ARRIVAL DATE is required'],
+  },
+  feetPerRoll: {
+    type: Number,
+    required: [true, 'FEET PER ROLL is required'],
+    min: 0
+  },
+  totalRolls: {
+    type: Number,
+    required: [true, 'TOTAL ROLLS is required'],
+    min: [TOTAL_ROLLS_MIN, 'Total Rolls cannot be less than 1'],
+    max: [TOTAL_ROLLS_MAX, 'Total Rolls cannot be greater than 100'],
+    validate: {
+      validator: Number.isInteger,
+      message: '{VALUE} is not an integer'
+    }
+  },
+  totalCost: {
+    type: Number,
+    required: [true, 'TOTAL COST is required'],
+    min: [TOTAL_COST_MIN * PENNIES_PER_DOLLAR, 'Total Cost must be more than $1'],
+    max: [TOTAL_COST_MAX * PENNIES_PER_DOLLAR, 'Total Cost must be less than $500,000'],
+    get: convertPenniesToDollars,
+    set: convertDollarsToPennies,
+  },
+  vendor: {
+    type: Schema.Types.ObjectId,
+    ref: 'Vendor',
+    required: [true, 'VENDOR is required'],
+  },
+  hasArrived: {
+    type: Boolean,
+    required: false
+  },
+  notes: {
+    type: String,
+    required: false
+  },
+  freightCharge: {
+    type: Number,
+    required: true,
+    get: convertPenniesToDollars,
+    set: convertDollarsToPennies,
+    min: 0
+  },
+  fuelCharge: {
+    type: Number,
+    required: true,
+    get: convertPenniesToDollars,
+    set: convertDollarsToPennies,
+    min: 0
+  }
 }, { timestamps: true, strict: 'throw' });
 
-schema.post([...createAndUpdateOneHooks, ...updateManyHooks], (result: IMaterialOrder | IMaterialOrder[]) => {
-  if (result instanceof Array) {
-    const materialIds = result.map(({material}) => material && material.toString());
-    populateMaterialInventories(materialIds);
-  } else {
+
+/* Unique Index */
+schema.index(
+  { purchaseOrderNumber: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { deleted: { $eq: false } }
+  }
+);
+
+
+/* Hooks */
+schema.post([...createAndUpdateOneHooks, ...updateManyHooks], (result: IMaterialOrder | UpdateWriteOpResult) => {
+  if ('material' in result) {
     populateMaterialInventories([result.material && result.material.toString()]);
+  } else {
+    populateMaterialInventories();
   }
 })
 
-schema.post(MongooseHooks.InsertMany, (docs: IMaterialOrder[]) => (populateMaterialInventories(docs.map(({material}) => material && material.toString()))))
+schema.post(MongooseHooks.InsertMany, (docs: IMaterialOrder[]) => (populateMaterialInventories(docs.map(({ material }) => material && material.toString()))))
 
 schema.post(MongooseHooks.BulkWrite, () => populateMaterialInventories())
 
-schema.post([...deleteOneHooks, ...deleteManyHooks], (_) => populateMaterialInventories())
+schema.post([...deleteOneHooks, ...deleteManyHooks], (_) => {
+  populateMaterialInventories()
+})
 
 
-export const MaterialOrderModel = mongoose.model('MaterialOrders', schema);
+/* Model */
+export const MaterialOrderModel = mongoose.model<IMaterialOrder, SoftDeleteModel<IMaterialOrder>>('MaterialOrder', schema);

--- a/application/react/Customer/CustomerTable/CustomerRowActions/CustomerRowActions.tsx
+++ b/application/react/Customer/CustomerTable/CustomerRowActions/CustomerRowActions.tsx
@@ -15,7 +15,7 @@ type Props = {
 }
 
 export const CustomerRowActions = ({ row, confirmation }: Props) => {
-  const { _id : mongooseObjectId } = row.original;
+  const { _id : mongooseObjectId, customerId } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -23,8 +23,8 @@ export const CustomerRowActions = ({ row, confirmation }: Props) => {
 
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
-      title: 'Delete Customer',
-      message: 'Are you sure you want to delete this customer? This action cannot be undone.',
+      title: 'Delete Customer?',
+      message: `Are you sure you want to delete this customer? This action cannot be undone. (Customer ID: "${customerId}")`,
       confirmText: 'Delete',
     });
 

--- a/application/react/DeliveryMethod/DeliveryMethodTable/DeliveryMethodRowActions/DeliveryMethodRowActions.tsx
+++ b/application/react/DeliveryMethod/DeliveryMethodTable/DeliveryMethodRowActions/DeliveryMethodRowActions.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const DeliveryMethodRowActions = (props: Props) => {
   const { row, confirmation } = props;
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, name: deliveryMethodName } = row.original as IDeliveryMethod;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -24,8 +24,8 @@ export const DeliveryMethodRowActions = (props: Props) => {
 
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
-      title: 'Delete Delivery Method',
-      message: 'Are you sure you want to delete this delivery method? This action cannot be undone.',
+      title: 'Delete Delivery Method?',
+      message: `Are you sure you want to delete this delivery method? This action cannot be undone. (Delivery Method Name: "${deliveryMethodName}")`,
       confirmText: 'Delete',
     });
 

--- a/application/react/Die/DieTable/DieRowActions/DieRowActions.tsx
+++ b/application/react/Die/DieTable/DieRowActions/DieRowActions.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export const DieRowActions = (props: Props) => {
   const { row, confirmation } = props;
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, dieNumber } = row.original as IDie;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -31,8 +31,8 @@ export const DieRowActions = (props: Props) => {
 
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
-      title: 'Delete Die',
-      message: 'Are you sure you want to delete this die? This action cannot be undone.',
+      title: 'Delete Die?',
+      message: `Are you sure you want to delete this die? This action cannot be undone. (Die Number: "${dieNumber}")`,
       confirmText: 'Delete',
     });
 

--- a/application/react/LinerType/LinerTypeTable/LinerTypeRowActions/LinerTypeRowActions.tsx
+++ b/application/react/LinerType/LinerTypeTable/LinerTypeRowActions/LinerTypeRowActions.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const LinerTypeRowActions = (props: Props) => {
   const { row, confirmation } = props
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, name: linerTypeName } = row.original as ILinerType;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -24,8 +24,8 @@ export const LinerTypeRowActions = (props: Props) => {
 
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
-      title: 'Delete Liner Type',
-      message: 'Are you sure you want to delete this liner type? This action cannot be undone.',
+      title: 'Delete Liner Type?',
+      message: `Are you sure you want to delete this liner type? This action cannot be undone. (Liner Type Name: "${linerTypeName}")`,
       confirmText: 'Delete',
     });
 

--- a/application/react/_global/Table/RowActions/RowActions.module.scss
+++ b/application/react/_global/Table/RowActions/RowActions.module.scss
@@ -85,6 +85,7 @@
 
   &:hover {
     background-color: rgba(115, 103, 240, .12);
+    cursor: pointer;
   }
 
   i {

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -59,7 +59,7 @@ describe('File: material.js', () => {
 
     it('should have the correct indexes', async () => {
         const indexMetaData = MaterialModel.schema.indexes();
-        const expectedIndexes = ['materialId', 'productNumber'];
+        const expectedIndexes = ['materialId'];
 
         console.log('indexMetaData: ', indexMetaData);
 
@@ -924,38 +924,8 @@ describe('File: material.js', () => {
             expect(savedMaterial.updatedAt).toBeDefined();
         });
 
-
-        it('should throw error if two materials with the same productNumber are saved to the DB', async () => {
-            const duplicateProductNumber = chance.string();
-            const material = new MaterialModel({
-                ...testDataGenerator.mockData.Material(),
-                productNumber: duplicateProductNumber
-            });
-            const materialWithDuplicateProductNumber = new MaterialModel({
-                ...testDataGenerator.mockData.Material(),
-                productNumber: duplicateProductNumber
-            });
-            const anothaMaterialWithDuplicateProductNumber = new MaterialModel({
-                ...testDataGenerator.mockData.Material(),
-                productNumber: duplicateProductNumber
-            });
-            let errorMessage;
-
-            await material.save();
-
-            try {
-                await materialWithDuplicateProductNumber.save();
-                await anothaMaterialWithDuplicateProductNumber.save();
-            } catch (error) {
-                errorMessage = error.message;
-            }
-
-            expect(errorMessage).toBeDefined();
-        });
-
-
         describe('attribute: materialId', () => {
-            it('should throw error if two materials with the same productNumber are saved to the DB', async () => {
+            it('should throw error if two materials with the same materialId are saved to the DB', async () => {
                 const duplicateMaterialId = chance.string();
                 const material = new MaterialModel({
                     ...testDataGenerator.mockData.Material(),

--- a/test/models/materialOrder.spec.js
+++ b/test/models/materialOrder.spec.js
@@ -405,16 +405,16 @@ describe('materialOrder validation', () => {
         });
 
         it('should update material.inventory each time insertMany is called', async () => {
-            await MaterialOrderModel.insertMany([materialOrderAttributes]);
-            await MaterialOrderModel.insertMany([materialOrderAttributes]);
+            await MaterialOrderModel.insertMany([testDataGenerator.mockData.MaterialOrder()]);
+            await MaterialOrderModel.insertMany([testDataGenerator.mockData.MaterialOrder()]);
         
             expect(populateMaterialInventoriesMock).toHaveBeenCalledTimes(2);
         });
 
         it('should update material.inventory each time bulkWrite is called', async () => {
-            await MaterialOrderModel.bulkWrite([{ insertOne: { document: materialOrderAttributes }}]);
-            await MaterialOrderModel.bulkWrite([{ insertOne: { document: materialOrderAttributes }}]);
-            await MaterialOrderModel.bulkWrite([{ insertOne: { document: materialOrderAttributes }}]);
+            await MaterialOrderModel.bulkWrite([{ insertOne: { document: testDataGenerator.mockData.MaterialOrder() }}]);
+            await MaterialOrderModel.bulkWrite([{ insertOne: { document: testDataGenerator.mockData.MaterialOrder() }}]);
+            await MaterialOrderModel.bulkWrite([{ insertOne: { document: testDataGenerator.mockData.MaterialOrder() }}]);
 
             // eslint-disable-next-line no-magic-numbers
             expect(populateMaterialInventoriesMock).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
# Description

Previously I had halfway gone down the path of soft deleting documents instead of deleting them completely from the database.

However, the approach wasn't standardized and had bugs everywhere - resulting in documents actually being deleted, and not soft deleted.

This PR standardizes the approach. I went through all the DB models and ensures that when a user deletes them from the UI - they remain in the database with a few new attributes that indicate they were deleted:

This should now allow us to revert any deletion, and also track down who performed a deletion.

```
{
    deleted: true,
    deletedBy: ObjectId('abc123'),
    deletedAt: 'datetime'
}
```