### PR TITLE
`E2E`: Add tests to verify deletions can be performed on every table within the UI 

### DIFF
--- a/application/react/_global/Modal/ConfirmationModal.tsx
+++ b/application/react/_global/Modal/ConfirmationModal.tsx
@@ -37,7 +37,7 @@ export const ConfirmationModal = ({
           <Button color="white" onClick={onClose}>
             {cancelText}
           </Button>
-          <Button color="red" onClick={handleConfirm}>
+          <Button color="red" onClick={handleConfirm} data-test="confirmation-modal-confirm-button">
             {confirmText}
           </Button>
         </div>

--- a/cypress/e2e/adhesiveCategory.cy.ts
+++ b/cypress/e2e/adhesiveCategory.cy.ts
@@ -45,7 +45,7 @@ describe('Adhesive Category Management', () => {
   it('should allow editing an existing adhesive category', () => {
     const updatedName = `${adhesiveCategory.name} Updated`;
     
-    // Find the row with our test category and click the edit button
+    // Find the row within the table and click the edit button
     cy.get('[data-test=adhesive-category-table]')
       .contains(uppercasedName)
       .closest('[data-test=table-row]')  // Get the row containing our text
@@ -69,6 +69,39 @@ describe('Adhesive Category Management', () => {
     cy.get('[data-test=adhesive-category-table]')
       .should('contain', uppercasedName);
   });
-});
 
+  it('should allow deleting an adhesive category', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=adhesive-category-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=adhesive-category-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=adhesive-category-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
+});
 

--- a/cypress/e2e/creditTerms.cy.ts
+++ b/cypress/e2e/creditTerms.cy.ts
@@ -77,26 +77,36 @@ describe('Credit Term Management', () => {
   });
 
   it('should allow deleting a credit term', () => {
-    // Find the row within the table and click the delete button
+    // First verify we have at least one row
     cy.get('[data-test=credit-term-table]')
-      .contains(uppercasedDescription)
-      .closest('[data-test=table-row]')
-      .find('[data-test=row-actions]')
-      .find('[data-test=row-actions-button]')
-      .click();
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=credit-term-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
 
-    // Click the delete button in the dropdown menu
-    cy.get('[data-test=row-actions-menu]')
-      .find('[data-test=row-action-item]')
-      .contains('Delete')
-      .click();
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
 
-    // Handle the confirmation modal
-    cy.get('[data-test=confirmation-modal-confirm-button]')
-      .should('be.visible')
-      .click();
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
 
-    // Verify the credit term is deleted
-    cy.get('[data-test=credit-term-table]').should('not.contain', uppercasedDescription);
+        // Verify the table has one less row
+        cy.get('[data-test=credit-term-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
   });
 });

--- a/cypress/e2e/creditTerms.cy.ts
+++ b/cypress/e2e/creditTerms.cy.ts
@@ -75,4 +75,28 @@ describe('Credit Term Management', () => {
     cy.get('[data-test=credit-term-table]')
       .should('contain', updatedDescription.toUpperCase());
   });
+
+  it('should allow deleting a credit term', () => {
+    // Find the row within the table and click the delete button
+    cy.get('[data-test=credit-term-table]')
+      .contains(uppercasedDescription)
+      .closest('[data-test=table-row]')
+      .find('[data-test=row-actions]')
+      .find('[data-test=row-actions-button]')
+      .click();
+
+    // Click the delete button in the dropdown menu
+    cy.get('[data-test=row-actions-menu]')
+      .find('[data-test=row-action-item]')
+      .contains('Delete')
+      .click();
+
+    // Handle the confirmation modal
+    cy.get('[data-test=confirmation-modal-confirm-button]')
+      .should('be.visible')
+      .click();
+
+    // Verify the credit term is deleted
+    cy.get('[data-test=credit-term-table]').should('not.contain', uppercasedDescription);
+  });
 });

--- a/cypress/e2e/customer.cy.ts
+++ b/cypress/e2e/customer.cy.ts
@@ -221,4 +221,38 @@ describe('Customer Management', () => {
     cy.get('[data-test=customer-table]')
       .should('contain', updatedName);
   });
+
+  it('should allow deleting a customer', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=customer-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=customer-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=customer-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });

--- a/cypress/e2e/deliveryMethod.cy.ts
+++ b/cypress/e2e/deliveryMethod.cy.ts
@@ -75,4 +75,38 @@ describe('Delivery Method Management', () => {
     cy.get('[data-test=delivery-method-table]')
       .should('contain', updatedName.toUpperCase());
   });
+
+  it('should allow deleting a delivery method', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=delivery-method-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=delivery-method-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=delivery-method-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });

--- a/cypress/e2e/die.cy.ts
+++ b/cypress/e2e/die.cy.ts
@@ -108,4 +108,38 @@ describe('Die Management', () => {
     cy.get('[data-test=die-table]')
       .should('contain', updatedSerialNumber);
   });
+
+  it('should allow deleting a die', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=die-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=die-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=die-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });

--- a/cypress/e2e/linerType.cy.ts
+++ b/cypress/e2e/linerType.cy.ts
@@ -69,6 +69,40 @@ describe('Liner Type Management', () => {
     cy.get('[data-test=liner-type-table]')
       .should('contain', uppercasedName);
   });
+
+  it('should allow deleting a liner type', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=liner-type-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=liner-type-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=liner-type-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });
 
 

--- a/cypress/e2e/material.cy.ts
+++ b/cypress/e2e/material.cy.ts
@@ -72,4 +72,38 @@ describe('Material Management', () => {
     cy.get('[data-test=material-table]')
       .should('contain', updatedName.toUpperCase());
   });
+
+  it('should allow deleting a material', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=material-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=material-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=material-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });

--- a/cypress/e2e/materialCategory.cy.ts
+++ b/cypress/e2e/materialCategory.cy.ts
@@ -69,6 +69,39 @@ describe('Material Category Management', () => {
     cy.get('[data-test=material-category-table]')
       .should('contain', uppercasedName);
   });
-});
 
+  it('should allow deleting a material category', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=material-category-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=material-category-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=material-category-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
+});
 

--- a/cypress/e2e/materialLengthAdjustment.cy.ts
+++ b/cypress/e2e/materialLengthAdjustment.cy.ts
@@ -65,6 +65,40 @@ describe('Material Length Adjustment Management', () => {
     cy.get('[data-test=material-length-adjustment-table]')
       .should('contain', getExpectedLengthFormat(updatedLength));
   });
+
+  it('should allow deleting a material length adjustment', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=material-length-adjustment-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=material-length-adjustment-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=material-length-adjustment-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });
 
 function getExpectedLengthFormat(length: number) {

--- a/cypress/e2e/materialOrder.cy.ts
+++ b/cypress/e2e/materialOrder.cy.ts
@@ -72,4 +72,38 @@ describe('Material Order Management', () => {
     cy.get('[data-test=material-order-table]')
       .should('contain', updatedPoNumber.toUpperCase());
   });
+
+  it('should allow deleting a material order', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=material-order-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=material-order-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=material-order-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });

--- a/cypress/e2e/vendor.cy.ts
+++ b/cypress/e2e/vendor.cy.ts
@@ -108,4 +108,38 @@ describe('Vendor Management', () => {
     cy.get('[data-test=vendor-table]')
       .should('contain', updatedName.toUpperCase());
   });
+
+  it('should allow deleting a vendor', () => {
+    // First verify we have at least one row
+    cy.get('[data-test=vendor-table]')
+      .find('[data-test=table-row]')
+      .should('have.length.at.least', 1)
+      .then(($rows) => {
+        const initialRowCount = $rows.length;
+        
+        // Click the actions menu on the first row
+        cy.get('[data-test=vendor-table]')
+          .find('[data-test=table-row]')
+          .first()
+          .find('[data-test=row-actions]')
+          .find('[data-test=row-actions-button]')
+          .click();
+
+        // Click the delete button in the dropdown menu
+        cy.get('[data-test=row-actions-menu]')
+          .find('[data-test=row-action-item]')
+          .contains('Delete')
+          .click();
+
+        // Handle the confirmation modal
+        cy.get('[data-test=confirmation-modal-confirm-button]')
+          .should('be.visible')
+          .click();
+
+        // Verify the table has one less row
+        cy.get('[data-test=vendor-table]')
+          .find('[data-test=table-row]')
+          .should('have.length', initialRowCount - 1);
+      });
+  });
 });


### PR DESCRIPTION
# Description

Currently we have many tables across the UI, used to view Documents of specific types. Each of those tables has an "actions", there should be a "delete" action.

This PR verifies the delete action can be clicked, and a confirmation modal appears before the deletion occurs.