### PR TITLE
Feat: Minor Tweaks to Table Column Widths

### DIFF
--- a/application/react/_global/Table/Row/Row.module.scss
+++ b/application/react/_global/Table/Row/Row.module.scss
@@ -18,5 +18,9 @@
     white-space: normal;
     word-break: break-word;
     overflow-wrap: break-word;
+
+    &:last-child {
+      flex: 0 0 100px; // Fixed width of 100px for the last column
+    }
   }
 }

--- a/application/react/_global/Table/RowActions/RowActions.module.scss
+++ b/application/react/_global/Table/RowActions/RowActions.module.scss
@@ -64,9 +64,9 @@
 .rowActions {
   position: relative;
   display: flex;
-  justify-content: flex-start;
   align-items: center;
   width: 100%;
+  margin-left: 5px;
 }
 
 .dropdownOptions.show {

--- a/application/react/_global/Table/RowHeader/RowHeader.module.scss
+++ b/application/react/_global/Table/RowHeader/RowHeader.module.scss
@@ -17,11 +17,13 @@
     align-items: center;
     flex: 1;
     padding: 0px;
-
     width: 100%;
     color: #323338;
     font-weight: 600;
 
+    &:last-child {
+      flex: 0 0 100px; // Fixed width of 100px for the last column
+    }
   }
 
   .columnIcon {


### PR DESCRIPTION
# Description

I've noticed for a long time that our columns are all the same widths. This includes the last column (the "action") button. The last column doesn't need all this width, so this PR shrinks it to 100px and gives the rest of the columns that width.

I was trying to create a better system for dynamically applying widths to columns, but the effort wasn't worth it, and this system will stay in place (all columns stay the same width) for now.