### PR TITLE
Improve Deletion Modal Text

### DIFF
--- a/application/react/AdhesiveCategory/AdhesiveCategoryTable/AdhesiveCategoryRowActions/AdhesiveCategoryRowActions.tsx
+++ b/application/react/AdhesiveCategory/AdhesiveCategoryTable/AdhesiveCategoryRowActions/AdhesiveCategoryRowActions.tsx
@@ -16,7 +16,7 @@ type Props = {
 }
 
 export const AdhesiveCategoryRowActions = ({ row, confirmation }: Props) => {
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, name } = row.original;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { showConfirmation } = confirmation;
@@ -24,7 +24,7 @@ export const AdhesiveCategoryRowActions = ({ row, confirmation }: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Adhesive Category',
-      message: 'Are you sure you want to delete this adhesive category? This action cannot be undone.',
+      message: (<span>Are you sure you want to delete "<strong>{name}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/CreditTerm/CreditTermTable/CreditTermRowActions/CreditTermRowActions.tsx
+++ b/application/react/CreditTerm/CreditTermTable/CreditTermRowActions/CreditTermRowActions.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 export const CreditTermRowActions = (props: Props) => {
   const { row, confirmation } = props;
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, description } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -26,7 +26,7 @@ export const CreditTermRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Credit Term',
-      message: 'Are you sure you want to delete this credit term? This action cannot be undone.',
+      message: (<span>Are you sure you want to delete "<strong>{description}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/Customer/CustomerTable/CustomerRowActions/CustomerRowActions.tsx
+++ b/application/react/Customer/CustomerTable/CustomerRowActions/CustomerRowActions.tsx
@@ -15,7 +15,7 @@ type Props = {
 }
 
 export const CustomerRowActions = ({ row, confirmation }: Props) => {
-  const { _id : mongooseObjectId, customerId } = row.original;
+  const { _id : mongooseObjectId, name } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -24,7 +24,7 @@ export const CustomerRowActions = ({ row, confirmation }: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Customer?',
-      message: `Are you sure you want to delete this customer? This action cannot be undone. (Customer ID: "${customerId}")`,
+      message: (<span>Are you sure you want to delete "<strong>{name}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/DeliveryMethod/DeliveryMethodTable/DeliveryMethodRowActions/DeliveryMethodRowActions.tsx
+++ b/application/react/DeliveryMethod/DeliveryMethodTable/DeliveryMethodRowActions/DeliveryMethodRowActions.tsx
@@ -25,7 +25,7 @@ export const DeliveryMethodRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Delivery Method?',
-      message: `Are you sure you want to delete this delivery method? This action cannot be undone. (Delivery Method Name: "${deliveryMethodName}")`,
+      message: (<span>Are you sure you want to delete "<strong>{deliveryMethodName}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/Die/DieTable/DieRowActions/DieRowActions.tsx
+++ b/application/react/Die/DieTable/DieRowActions/DieRowActions.tsx
@@ -32,7 +32,7 @@ export const DieRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Die?',
-      message: `Are you sure you want to delete this die? This action cannot be undone. (Die Number: "${dieNumber}")`,
+      message: (<span>Are you sure you want to delete "<strong>{dieNumber}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/LinerType/LinerTypeTable/LinerTypeRowActions/LinerTypeRowActions.tsx
+++ b/application/react/LinerType/LinerTypeTable/LinerTypeRowActions/LinerTypeRowActions.tsx
@@ -25,7 +25,7 @@ export const LinerTypeRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Liner Type?',
-      message: `Are you sure you want to delete this liner type? This action cannot be undone. (Liner Type Name: "${linerTypeName}")`,
+      message: (<span>Are you sure you want to delete "<strong>{linerTypeName}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/Material/MaterialTable/MaterialRowActions/MaterialRowActions.tsx
+++ b/application/react/Material/MaterialTable/MaterialRowActions/MaterialRowActions.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const MaterialRowActions = (props: Props) => {
   const { row, confirmation } = props
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, name } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -25,7 +25,7 @@ export const MaterialRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Material',
-      message: 'Are you sure you want to delete this material? This action cannot be undone.',
+      message: (<span>Are you sure you want to delete "<strong>{name}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/MaterialCategory/MaterialCategoryTable/MaterialCategoryRowActions/MaterialCategoryRowActions.tsx
+++ b/application/react/MaterialCategory/MaterialCategoryTable/MaterialCategoryRowActions/MaterialCategoryRowActions.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const MaterialCategoryRowActions = (props: Props) => {
   const { row, confirmation } = props;
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, name } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -25,7 +25,7 @@ export const MaterialCategoryRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseIdStr) => {
     const confirmed = await showConfirmation({
       title: 'Delete Material Category',
-      message: 'Are you sure you want to delete this material category? This action cannot be undone.',
+      message: (<span>Are you sure you want to delete "<strong>{name}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 
@@ -45,8 +45,8 @@ export const MaterialCategoryRowActions = (props: Props) => {
 
   return (
     <RowActions>
-      <RowActionItem text='Edit' Icon={IoCreateOutline} onClick={() => onEditClicked(mongooseObjectId)} />
-      <RowActionItem text='Delete' Icon={IoTrashOutline} onClick={() => onDeleteClicked(mongooseObjectId)} />
+      <RowActionItem text='Edit' Icon={IoCreateOutline} onClick={() => onEditClicked(mongooseObjectId as MongooseIdStr)} />
+      <RowActionItem text='Delete' Icon={IoTrashOutline} onClick={() => onDeleteClicked(mongooseObjectId as MongooseIdStr)} />
     </RowActions>
   )
 }

--- a/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentTable/MaterialLengthAdjustmentRowActions/MaterialLengthAdjustmentRowActions.tsx
+++ b/application/react/MaterialLengthAdjustment/MaterialLengthAdjustmentTable/MaterialLengthAdjustmentRowActions/MaterialLengthAdjustmentRowActions.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useSuccessMessage } from '../../../_hooks/useSuccessMessage';
 import { useErrorMessage } from '../../../_hooks/useErrorMessage';
 import { IoCreateOutline, IoTrashOutline } from 'react-icons/io5';
-import { IMaterialLengthAdjustment } from '@shared/types/models';
+import { IMaterial, IMaterialLengthAdjustment } from '@shared/types/models';
 import { MongooseIdStr } from '@shared/types/typeAliases';
 import { ConfirmationResult } from '../../../_global/Modal/useConfirmation';
 
@@ -17,7 +17,7 @@ type Props = {
 
 export const MaterialLengthAdjustmentRowActions = (props: Props) => {
   const { row, confirmation } = props;
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, material } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -27,7 +27,7 @@ export const MaterialLengthAdjustmentRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseIdStr) => {
     const confirmed = await showConfirmation({
       title: 'Delete Material Length Adjustment',
-      message: 'Are you sure you want to delete this material length adjustment? This action cannot be undone.',
+      message: (<span>Are you sure you want to delete the adjustment for "<strong>{(material as IMaterial).name}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/MaterialOrder/MaterialOrderTable/MaterialOrderRowActions/MaterialOrderRowActions.tsx
+++ b/application/react/MaterialOrder/MaterialOrderTable/MaterialOrderRowActions/MaterialOrderRowActions.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const MaterialOrderRowActions = (props: Props) => {
   const { row, confirmation } = props;
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, purchaseOrderNumber } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -25,7 +25,7 @@ export const MaterialOrderRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Material Order',
-      message: 'Are you sure you want to delete this material order? This action cannot be undone.',
+      message: (<span>Are you sure you want to delete "<strong>{purchaseOrderNumber}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/Vendor/VendorTable/VendorRowActions/VendorRowActions.tsx
+++ b/application/react/Vendor/VendorTable/VendorRowActions/VendorRowActions.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 export const VendorRowActions = (props: Props) => {
   const { row, confirmation } = props;
-  const { _id: mongooseObjectId } = row.original;
+  const { _id: mongooseObjectId, name } = row.original;
   const { showConfirmation } = confirmation;
 
   const navigate = useNavigate();
@@ -26,7 +26,7 @@ export const VendorRowActions = (props: Props) => {
   const onDeleteClicked = async (mongooseObjectId: MongooseId) => {
     const confirmed = await showConfirmation({
       title: 'Delete Vendor',
-      message: 'Are you sure you want to delete this vendor? This action cannot be undone.',
+      message: (<span>Are you sure you want to delete "<strong>{name}</strong>"? <br /> This action cannot be undone.</span>),
       confirmText: 'Delete',
     });
 

--- a/application/react/_global/Modal/ConfirmationModal.tsx
+++ b/application/react/_global/Modal/ConfirmationModal.tsx
@@ -7,37 +7,24 @@ type Props = {
   onClose: () => void;
   onConfirm: () => void;
   title: string;
-  message: string;
-  confirmText?: string;
-  cancelText?: string;
-}
+  message: string | JSX.Element;
+  confirmText: string;
+  cancelText: string;
+};
 
-export const ConfirmationModal = ({
-  isOpen,
-  onClose,
-  onConfirm,
-  title,
-  message,
-  confirmText = 'Confirm',
-  cancelText = 'Cancel'
-}: Props) => {
+export const ConfirmationModal = ({ isOpen, onClose, onConfirm, title, message, confirmText, cancelText }: Props) => {
   if (!isOpen) return null;
-
-  const handleConfirm = () => {
-    onConfirm();
-    onClose();
-  };
 
   return (
     <Modal onClose={onClose}>
       <div className={styles.confirmationContent}>
         <h2 className={styles.title}>{title}</h2>
-        <p className={styles.message}>{message}</p>
+        <div className={styles.message}>{message}</div>
         <div className={styles.actions}>
           <Button color="white" onClick={onClose}>
             {cancelText}
           </Button>
-          <Button color="red" onClick={handleConfirm} data-test="confirmation-modal-confirm-button">
+          <Button color="red" onClick={onConfirm}>
             {confirmText}
           </Button>
         </div>

--- a/application/react/_global/Modal/useConfirmation.tsx
+++ b/application/react/_global/Modal/useConfirmation.tsx
@@ -3,7 +3,7 @@ import { ConfirmationModal } from './ConfirmationModal';
 
 type ConfirmationOptions = {
   title?: string;
-  message: string;
+  message: string | JSX.Element;
   confirmText?: string;
   cancelText?: string;
 };
@@ -46,8 +46,8 @@ export const useConfirmation = (): ConfirmationResult => {
         onConfirm={handleConfirm}
         title={options.title || 'Confirm Action'}
         message={options.message}
-        confirmText={options.confirmText}
-        cancelText={options.cancelText}
+        confirmText={options.confirmText || 'Confirm'}
+        cancelText={options.cancelText || 'Cancel'}
       />
     );
   }, [isOpen, options, handleClose, handleConfirm]);

--- a/application/react/_global/Table/TablePageHeader/TablePageHeader.tsx
+++ b/application/react/_global/Table/TablePageHeader/TablePageHeader.tsx
@@ -38,7 +38,7 @@ export const TablePageHeader: React.FC<TablePageHeaderProps> = ({
         />
         {createButton && (
           <IconButton
-            color="purple"
+            color="green"
             to={createButton.to}
             tooltip={createButton.tooltip || `Create new ${title.toLowerCase()}`}
             icon={<GoPlus />}


### PR DESCRIPTION
# Description

I noticed when deleting things, that the confirmation modal didn't confirm to the user what exactly they had clicked to delete.

So if they clicked delete on the wrong thing, there was no way they'd know before it was deleted.

After this PR, info, such as the name, of what they clicked delete on are displayed. Eventually I might even have them type this name in the modal - someday.