### PR TITLE
Remove Try/Catch's in API and Use Express V5 Global Error Handler Middleware

### DIFF
--- a/application/api/controllers/adhesiveCategoryController.ts
+++ b/application/api/controllers/adhesiveCategoryController.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response, RequestHandler } from 'express';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { AdhesiveCategoryModel } from '../models/adhesiveCategory.ts';
-import { BAD_REQUEST, CREATED_SUCCESSFULLY, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { getSortOption } from '../services/mongooseService.ts';
@@ -13,134 +13,98 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { name: { $regex: query, $options: 'i' } }
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await AdhesiveCategoryModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0;
-    const adhesiveCategories = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<IAdhesiveCategory> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: adhesiveCategories,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-  } catch (error) {
-    console.error('Error during adhesiveCategory search:', error);
-    response.status(500).send(error);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { name: { $regex: query, $options: 'i' } }
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await AdhesiveCategoryModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0;
+  const adhesiveCategories = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<IAdhesiveCategory> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: adhesiveCategories,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedAdhesiveCategory = await AdhesiveCategoryModel.deleteById(request.params.mongooseId, request.user._id)
+  const deletedAdhesiveCategory = await AdhesiveCategoryModel.deleteById(request.params.mongooseId, request.user._id)
 
-    response.status(SUCCESS).json(deletedAdhesiveCategory);
-  } catch (error) {
-    console.error('Failed to delete adhesiveCategory: ', error);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedAdhesiveCategory);
 }) as RequestHandler);
 
 router.get('/', (async (_: Request, response: Response) => {
-  try {
-    const adhesiveCategories = await AdhesiveCategoryModel.find().exec();
+  const adhesiveCategories = await AdhesiveCategoryModel.find().exec();
 
-    response.json(adhesiveCategories);
-  } catch (error) {
-    console.error('Error fetching adhesive category: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(adhesiveCategories);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedAdhesiveCategory = await AdhesiveCategoryModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedAdhesiveCategory = await AdhesiveCategoryModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedAdhesiveCategory);
-  } catch (error) {
-    console.error('Failed to update adhesiveCategory: ', error);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedAdhesiveCategory);
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  let savedAdhesiveCategory;
+  const savedAdhesiveCategory = await AdhesiveCategoryModel.create(request.body);
 
-  try {
-    savedAdhesiveCategory = await AdhesiveCategoryModel.create(request.body);
-
-    response.status(CREATED_SUCCESSFULLY).send(savedAdhesiveCategory);
-  } catch (error) {
-    console.error('Error creating adhesive category: ', error);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).send(savedAdhesiveCategory);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const adhesiveCategory = await AdhesiveCategoryModel.findById(request.params.mongooseId);
+  const adhesiveCategory = await AdhesiveCategoryModel.findById(request.params.mongooseId);
 
-    response.json(adhesiveCategory);
-  } catch (error) {
-    console.error('Error searching for adhesiveCategory: ', error);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(adhesiveCategory);
 }) as RequestHandler);
 
 

--- a/application/api/controllers/creditTermsController.ts
+++ b/application/api/controllers/creditTermsController.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, RequestHandler } from 'express';
-import { SUCCESS, SERVER_ERROR, BAD_REQUEST, CREATED_SUCCESSFULLY } from '../enums/httpStatusCodes.ts';
+import { SUCCESS, BAD_REQUEST, CREATED_SUCCESSFULLY } from '../enums/httpStatusCodes.ts';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { CreditTermModel } from '../models/creditTerm.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
@@ -13,117 +13,92 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { description: { $regex: query, $options: 'i' } },
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await CreditTermModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const creditTerms = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<ICreditTerm> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: creditTerms,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-  } catch (error) {
-    console.error('Error during material-length-adjustment search:', error);
-    response.status(500).send(error);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { description: { $regex: query, $options: 'i' } },
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await CreditTermModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const creditTerms = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<ICreditTerm> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: creditTerms,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  let savedCreditTerm;
+  const savedCreditTerm = await CreditTermModel.create(request.body);
 
-  try {
-    savedCreditTerm = await CreditTermModel.create(request.body);
-    response.status(CREATED_SUCCESSFULLY).send(savedCreditTerm);
-  } catch (error) {
-    console.log(error);
-    response.status(BAD_REQUEST).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).send(savedCreditTerm);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedCreditTerm = await CreditTermModel.deleteById(request.params.mongooseId, request.user._id)
+  const deletedCreditTerm = await CreditTermModel.deleteById(request.params.mongooseId, request.user._id)
 
-    response.status(SUCCESS).json(deletedCreditTerm);
-  } catch (error) {
-    console.error('Failed to delete creditTerm: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedCreditTerm);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedCreditTerm = await CreditTermModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedCreditTerm = await CreditTermModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedCreditTerm);
-  } catch (error) {
-    console.error('Failed to update creditTerm: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedCreditTerm);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const creditTerm = await CreditTermModel.findById(request.params.mongooseId);
-    response.json(creditTerm);
-  } catch (error) {
-    console.error('Error searching for creditTerm: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const creditTerm = await CreditTermModel.findById(request.params.mongooseId);
+
+  response.json(creditTerm);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/customerController.ts
+++ b/application/api/controllers/customerController.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, RequestHandler } from 'express';
-import { SERVER_ERROR, CREATED_SUCCESSFULLY, SUCCESS, BAD_REQUEST } from '../enums/httpStatusCodes.ts';
+import { CREATED_SUCCESSFULLY, SUCCESS, BAD_REQUEST } from '../enums/httpStatusCodes.ts';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { CustomerModel } from '../models/customer.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
@@ -13,152 +13,119 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { customerId: { $regex: query, $options: 'i' } },
-          { name: { $regex: query, $options: 'i' } },
-          { notes: { $regex: query, $options: 'i' } }
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $lookup: {
-          from: 'creditterms',
-          localField: 'creditTerms',
-          foreignField: '_id',
-          as: 'creditTerms',
-        },
-      },
-      {
-        $unwind: {
-          path: '$creditterms',
-          preserveNullAndEmptyArrays: true, // In case material is not populated
-        },
-      },
-      // Text search
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      // Pagination and sorting
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await CustomerModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const customers = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<ICustomer> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: customers,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-
-  } catch (error) {
-    console.error('Failed to search for customers: ', error);
-    response.status(SERVER_ERROR).send(error.message);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { customerId: { $regex: query, $options: 'i' } },
+        { name: { $regex: query, $options: 'i' } },
+        { notes: { $regex: query, $options: 'i' } }
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'creditterms',
+        localField: 'creditTerms',
+        foreignField: '_id',
+        as: 'creditTerms',
+      },
+    },
+    {
+      $unwind: {
+        path: '$creditterms',
+        preserveNullAndEmptyArrays: true, // In case material is not populated
+      },
+    },
+    // Text search
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    // Pagination and sorting
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await CustomerModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const customers = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<ICustomer> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: customers,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.get('/', (async (_: Request, response: Response) => {
-  try {
-    const customers = await CustomerModel.find().exec();
+  const customers = await CustomerModel.find().exec();
 
-    response.json(customers);
-  } catch (error) {
-    console.error('Error fetching customers: ', error.message);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(customers);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const customer = await CustomerModel.deleteById(request.params.mongooseId, request.user._id)
+  const customer = await CustomerModel.deleteById(request.params.mongooseId, request.user._id)
 
-    response.status(SUCCESS).json(customer);
-  } catch (error) {
-    console.error('Failed to delete customer: ', error.message);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(customer);
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const customer = await CustomerModel.create(request.body);
-    response.status(CREATED_SUCCESSFULLY).json(customer);
-  } catch (error) {
-    console.log('Error creating customer: ', error.message);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const customer = await CustomerModel.create(request.body);
+
+  response.status(CREATED_SUCCESSFULLY).json(customer);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedCustomer = await CustomerModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedCustomer = await CustomerModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedCustomer);
-  } catch (error) {
-    console.error('Failed to update customer: ', error.message);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedCustomer);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const customer = await CustomerModel.findById(request.params.mongooseId)
-      .populate<{ creditTerms: ICreditTerm[] }>('creditTerms')
-      .orFail(new Error(`Customer not found using ID '${request.params.mongooseId}'`))
-      .exec();
+  const customer = await CustomerModel.findById(request.params.mongooseId)
+    .populate<{ creditTerms: ICreditTerm[] }>('creditTerms')
+    .orFail(new Error(`Customer not found using ID '${request.params.mongooseId}'`))
+    .exec();
 
-    response.json(customer);
-  } catch (error) {
-    console.error('Error searching for customer: ', error.message);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(customer);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/deliveryMethodController.ts
+++ b/application/api/controllers/deliveryMethodController.ts
@@ -1,63 +1,43 @@
 import { Router, Request, Response, RequestHandler } from 'express';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { DeliveryMethodModel } from '../models/deliveryMethod.ts';
-import { SUCCESS, SERVER_ERROR, BAD_REQUEST, CREATED_SUCCESSFULLY } from '../enums/httpStatusCodes.ts';
+import { SUCCESS, CREATED_SUCCESSFULLY } from '../enums/httpStatusCodes.ts';
 
 const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/', (async (_: Request, response: Response) => {
-  try {
-    const deliveryMethods = await DeliveryMethodModel.find().exec();
-    response.send(deliveryMethods);
-  } catch (error) {
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const deliveryMethods = await DeliveryMethodModel.find().exec();
+
+  response.send(deliveryMethods);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedDeliveryMethod = await DeliveryMethodModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedDeliveryMethod = await DeliveryMethodModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedDeliveryMethod);
-  } catch (error) {
-    console.error('Failed to update deliveryMethod: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedDeliveryMethod);
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const savedDeliveryMethod = await DeliveryMethodModel.create(request.body);
-    response.status(CREATED_SUCCESSFULLY).send(savedDeliveryMethod);
-  } catch (error) {
-    console.error('Failed to create deliveryMethod', error);
-    response.status(BAD_REQUEST).send(error.message);
-  }
+  const savedDeliveryMethod = await DeliveryMethodModel.create(request.body);
+
+  response.status(CREATED_SUCCESSFULLY).send(savedDeliveryMethod);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedDeliveryMethod = await DeliveryMethodModel.deleteById(request.params.mongooseId, request.user._id);
-    response.status(SUCCESS).json(deletedDeliveryMethod);
-  } catch (error) {
-    console.error('Failed to delete deliveryMethod: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const deletedDeliveryMethod = await DeliveryMethodModel.deleteById(request.params.mongooseId, request.user._id);
+
+  response.status(SUCCESS).json(deletedDeliveryMethod);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deliveryMethod = await DeliveryMethodModel.findById(request.params.mongooseId);
-    response.json(deliveryMethod);
-  } catch (error) {
-    console.error('Error searching for deliveryMethod: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const deliveryMethod = await DeliveryMethodModel.findById(request.params.mongooseId);
+
+  response.json(deliveryMethod);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/dieController.ts
+++ b/application/api/controllers/dieController.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response, RequestHandler } from 'express';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { DieModel } from '../models/die.ts';
 import { IDie } from '@shared/types/models.ts';
-import { BAD_REQUEST, CREATED_SUCCESSFULLY, NOT_FOUND, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, NOT_FOUND, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { getSortOption } from '../services/mongooseService.ts';
@@ -13,130 +13,105 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    await DieModel.create(request.body);
+  await DieModel.create(request.body);
 
-    response.status(CREATED_SUCCESSFULLY).send();
-  } catch (error) {
-    console.error('Failed to create die:', error.message);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).send();
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedDie = await DieModel.findByIdAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).orFail(new Error(`Die not found using ID '${request.params.mongooseId}'`)).exec();
+  const updatedDie = await DieModel.findByIdAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).orFail(new Error(`Die not found using ID '${request.params.mongooseId}'`)).exec();
 
-    response.json(updatedDie);
-  } catch (error) {
-    console.error('Failed to update die:', error.message);
-    response.status(BAD_REQUEST).send(error.message);
-  }
+  response.json(updatedDie);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedDie = await DieModel.deleteById(request.params.mongooseId, request.user._id)
+  const deletedDie = await DieModel.deleteById(request.params.mongooseId, request.user._id)
 
-    response.status(SUCCESS).json(deletedDie);
-  } catch (error) {
-    console.error('Failed to delete die: ', error);
-    response.status(SERVER_ERROR).send(error);
-  }
+  response.status(SUCCESS).json(deletedDie);
 }) as RequestHandler);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { dieNumber: { $regex: query, $options: 'i' } },
-          { shape: { $regex: query, $options: 'i' } },
-          { notes: { $regex: query, $options: 'i' } },
-          { vendor: { $regex: query, $options: 'i' } },
-          { vendor: { $regex: query, $options: 'i' } },
-          { liner: { $regex: query, $options: 'i' } },
-          { serialNumber: { $regex: query, $options: 'i' } }
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await DieModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const dies = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<IDie> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: dies,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-  } catch (error) {
-    console.error('Error during material-length-adjustment search:', error);
-    response.status(500).send(error);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { dieNumber: { $regex: query, $options: 'i' } },
+        { shape: { $regex: query, $options: 'i' } },
+        { notes: { $regex: query, $options: 'i' } },
+        { vendor: { $regex: query, $options: 'i' } },
+        { vendor: { $regex: query, $options: 'i' } },
+        { liner: { $regex: query, $options: 'i' } },
+        { serialNumber: { $regex: query, $options: 'i' } }
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await DieModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const dies = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<IDie> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: dies,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const die = await DieModel.findById(request.params.mongooseId)
-      .orFail(new Error(`Die not found using ID '${request.params.mongooseId}'`))
-      .exec();
+  const die = await DieModel.findById(request.params.mongooseId)
+    .orFail(new Error(`Die not found using ID '${request.params.mongooseId}'`))
+    .exec();
 
-    if (!die) {
-      response.status(NOT_FOUND).send('Die not found');
-      return;
-    }
-
-    response.json(die);
-  } catch (error) {
-    console.error('Error fetching die: ', error.message);
-    response.status(SERVER_ERROR).send(error.message);
+  if (!die) {
+    response.status(NOT_FOUND).send('Die not found');
+    return;
   }
+
+  response.json(die);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/linerTypeController.ts
+++ b/application/api/controllers/linerTypeController.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response, RequestHandler } from 'express';
 import { LinerTypeModel } from '../models/linerType.ts';
 import { verifyBearerToken } from '../middleware/authorize.ts';
-import { BAD_REQUEST, CREATED_SUCCESSFULLY, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { getSortOption } from '../services/mongooseService.ts';
@@ -13,117 +13,92 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { name: { $regex: query, $options: 'i' } }
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await LinerTypeModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const linerTypes = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<ILinerType> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: linerTypes,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-  } catch (error) {
-    console.error('Error during linerTypes search:', error);
-    response.status(500).send(error);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { name: { $regex: query, $options: 'i' } }
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await LinerTypeModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const linerTypes = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<ILinerType> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: linerTypes,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedLinerType = await LinerTypeModel.deleteById(request.params.mongooseId, request.user._id)
+  const deletedLinerType = await LinerTypeModel.deleteById(request.params.mongooseId, request.user._id)
 
-    response.status(SUCCESS).json(deletedLinerType);
-  } catch (error) {
-    console.error('Failed to delete LinerType: ', error);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedLinerType);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedLinerType = await LinerTypeModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedLinerType = await LinerTypeModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedLinerType);
-  } catch (error) {
-    console.log('Failed to update LinerType: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedLinerType);
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const linerType = await LinerTypeModel.create(request.body);
+  const linerType = await LinerTypeModel.create(request.body);
 
-    response.status(CREATED_SUCCESSFULLY).json(linerType);
-  } catch (error) {
-    console.error('Failed to create LinerType: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).json(linerType);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const linerType = await LinerTypeModel.findById(request.params.mongooseId);
-    response.json(linerType);
-  } catch (error) {
-    console.error('Error searching for linerType: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const linerType = await LinerTypeModel.findById(request.params.mongooseId);
+
+  response.json(linerType);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/materialCategoryController.ts
+++ b/application/api/controllers/materialCategoryController.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response, RequestHandler } from 'express';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { MaterialCategoryModel } from '../models/materialCategory.ts';
-import { BAD_REQUEST, CREATED_SUCCESSFULLY, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { getSortOption } from '../services/mongooseService.ts';
@@ -13,124 +13,94 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { name: { $regex: query, $options: 'i' } }
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await MaterialCategoryModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const materialCategories = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<IMaterialCategory> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: materialCategories,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-
-  } catch (error) {
-    console.error('Error during materialCategories search:', error);
-    response.status(SERVER_ERROR).send(error);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { name: { $regex: query, $options: 'i' } }
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await MaterialCategoryModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const materialCategories = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<IMaterialCategory> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: materialCategories,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const materialCategory = await MaterialCategoryModel.create(request.body);
+  const materialCategory = await MaterialCategoryModel.create(request.body);
 
-    response.status(CREATED_SUCCESSFULLY).json(materialCategory);
-  } catch (error) {
-    console.error('Failed to create materialCategory: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).json(materialCategory);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
   const { mongooseId } = request.params;
 
-  try {
-    await MaterialCategoryModel.deleteById(mongooseId, request.user._id);
+  await MaterialCategoryModel.deleteById(mongooseId, request.user._id);
 
-    response.sendStatus(SUCCESS);
-  } catch (error) {
-    console.log(error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.sendStatus(SUCCESS);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const materialCategory = await MaterialCategoryModel.findById(request.params.mongooseId);
+  const materialCategory = await MaterialCategoryModel.findById(request.params.mongooseId);
 
-    response.json(materialCategory);
-  } catch (error) {
-    console.error('Error searching for materialCategory: ', error);
-
-    response
-      .status(SERVER_ERROR)
-      .send(error.message);
-  }
+  response.json(materialCategory);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedMaterialCategory = await MaterialCategoryModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedMaterialCategory = await MaterialCategoryModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedMaterialCategory);
-  } catch (error) {
-    console.error('Failed to update materialCategory: ', error);
-
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedMaterialCategory);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/materialController.ts
+++ b/application/api/controllers/materialController.ts
@@ -4,7 +4,7 @@ import { verifyBearerToken } from '../middleware/authorize.ts';
 import * as materialInventoryService from '../services/materialInventoryService.ts';
 import * as mongooseService from '../services/mongooseService.ts';
 
-import { BAD_REQUEST, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { DEFAULT_SORT_OPTIONS } from '../constants/mongoose.ts';
@@ -15,206 +15,171 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = mongooseService.getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { name: { $regex: query, $options: 'i' } },
-          { materialId: { $regex: query, $options: 'i' } },
-          { description: { $regex: query, $options: 'i' } },
-          { 'vendor.name': { $regex: query, $options: 'i' } },
-          { 'adhesiveCategory.name': { $regex: query, $options: 'i' } }
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $lookup: {
-          from: 'vendors',
-          localField: 'vendor',
-          foreignField: '_id',
-          as: 'vendor',
-        },
-      },
-      {
-        $lookup: {
-          from: 'materialcategories',
-          localField: 'materialCategory',
-          foreignField: '_id',
-          as: 'materialCategory',
-        },
-      },
-      {
-        $lookup: {
-          from: 'adhesivecategories',
-          localField: 'adhesiveCategory',
-          foreignField: '_id',
-          as: 'adhesiveCategory',
-        },
-      },
-      {
-        $lookup: {
-          from: 'linertypes',
-          localField: 'linerType',
-          foreignField: '_id',
-          as: 'linerType',
-        },
-      },
-      {
-        $unwind: {
-          path: '$vendor',
-          preserveNullAndEmptyArrays: true, // In case material is not populated
-        },
-      },
-      {
-        $unwind: {
-          path: '$materialCategory',
-          preserveNullAndEmptyArrays: true, // In case materialCategory is not populated
-        },
-      },
-      {
-        $unwind: {
-          path: '$adhesiveCategory',
-          preserveNullAndEmptyArrays: true, // In case adhesiveCategory is not populated
-        },
-      },
-      {
-        $unwind: {
-          path: '$linerType',
-          preserveNullAndEmptyArrays: true, // In case linerType is not populated
-        },
-      },
-      // Text search
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      // Pagination and sorting
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await MaterialModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const materials = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<IMaterial> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: materials,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-  } catch (error) {
-    console.error('Failed to search for materials: ', error);
-    response.status(SERVER_ERROR).send(error.message);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = mongooseService.getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { name: { $regex: query, $options: 'i' } },
+        { materialId: { $regex: query, $options: 'i' } },
+        { description: { $regex: query, $options: 'i' } },
+        { 'vendor.name': { $regex: query, $options: 'i' } },
+        { 'adhesiveCategory.name': { $regex: query, $options: 'i' } }
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'vendors',
+        localField: 'vendor',
+        foreignField: '_id',
+        as: 'vendor',
+      },
+    },
+    {
+      $lookup: {
+        from: 'materialcategories',
+        localField: 'materialCategory',
+        foreignField: '_id',
+        as: 'materialCategory',
+      },
+    },
+    {
+      $lookup: {
+        from: 'adhesivecategories',
+        localField: 'adhesiveCategory',
+        foreignField: '_id',
+        as: 'adhesiveCategory',
+      },
+    },
+    {
+      $lookup: {
+        from: 'linertypes',
+        localField: 'linerType',
+        foreignField: '_id',
+        as: 'linerType',
+      },
+    },
+    {
+      $unwind: {
+        path: '$vendor',
+        preserveNullAndEmptyArrays: true, // In case material is not populated
+      },
+    },
+    {
+      $unwind: {
+        path: '$materialCategory',
+        preserveNullAndEmptyArrays: true, // In case materialCategory is not populated
+      },
+    },
+    {
+      $unwind: {
+        path: '$adhesiveCategory',
+        preserveNullAndEmptyArrays: true, // In case adhesiveCategory is not populated
+      },
+    },
+    {
+      $unwind: {
+        path: '$linerType',
+        preserveNullAndEmptyArrays: true, // In case linerType is not populated
+      },
+    },
+    // Text search
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    // Pagination and sorting
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await MaterialModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const materials = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<IMaterial> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: materials,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedMaterial = await MaterialModel.deleteById(request.params.mongooseId, request.user._id)
+  const deletedMaterial = await MaterialModel.deleteById(request.params.mongooseId, request.user._id)
 
-    response.status(SUCCESS).json(deletedMaterial);
-  } catch (error) {
-    console.error('Failed to delete material: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedMaterial);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedMaterial = await MaterialModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedMaterial = await MaterialModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedMaterial);
-  } catch (error) {
-    console.error('Failed to update material: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedMaterial);
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const material = await MaterialModel.create(request.body);
+  const material = await MaterialModel.create(request.body);
 
-    response.json(material);
-  } catch (error) {
-    console.log('Error creating material: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(material);
 }) as RequestHandler);
 
 router.get('/recalculate-inventory', (async (_: Request, response: Response) => {
-  try {
-    await materialInventoryService.populateMaterialInventories();
+  await materialInventoryService.populateMaterialInventories();
 
-    response.sendStatus(SUCCESS);
-  } catch (error) {
-    console.log('Error populating material inventories.', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.sendStatus(SUCCESS);
 }) as RequestHandler);
 
 router.get('/', (async (_: Request, response: Response) => {
-  try {
-    const materials = await MaterialModel.find()
-      .populate('vendor')
-      .populate('materialCategory')
-      .populate('adhesiveCategory')
-      .populate('linerType')
-      .exec();
+  const materials = await MaterialModel.find()
+    .populate('vendor')
+    .populate('materialCategory')
+    .populate('adhesiveCategory')
+    .populate('linerType')
+    .exec();
 
-    response.json(materials);
-  } catch (error) {
-    console.error('Error searching for materials: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(materials);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const material = await MaterialModel.findById(request.params.mongooseId);
+  const material = await MaterialModel.findById(request.params.mongooseId);
 
-    response.json(material);
-  } catch (error) {
-    console.error('Error searching for material: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(material);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/materialLengthAdjustmentController.ts
+++ b/application/api/controllers/materialLengthAdjustmentController.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, RequestHandler } from 'express';
-import { BAD_REQUEST, CREATED_SUCCESSFULLY, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { IMaterialLengthAdjustment } from '@shared/types/models.ts';
 import { MaterialLengthAdjustmentModel } from '../models/materialLengthAdjustment.ts';
@@ -13,160 +13,130 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.post('/batch', (async (request: Request, response: Response) => {
-  try {
-    const { ids } = request.body;
+  const { ids } = request.body;
 
-    if (!Array.isArray(ids) || ids.length === 0) {
-      response.status(400).json({ error: "'ids' is invalid" });
-      return;
-    }
-
-    const orders = await MaterialLengthAdjustmentModel
-      .find({ _id: { $in: ids } })
-      .populate('material')
-      .exec();
-
-    response.json(orders);
-  } catch (error) {
-    console.error('Failed to fetch materialLengthAdjustments by ids', error);
-    response.status(BAD_REQUEST).send(error.message);
+  if (!Array.isArray(ids) || ids.length === 0) {
+    response.status(400).json({ error: "'ids' is invalid" });
+    return;
   }
+
+  const orders = await MaterialLengthAdjustmentModel
+    .find({ _id: { $in: ids } })
+    .populate('material')
+    .exec();
+
+  response.json(orders);
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const savedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.create(request.body);
+  const savedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.create(request.body);
 
-    response.status(CREATED_SUCCESSFULLY).send(savedMaterialLengthAdjustment);
-  } catch (error) {
-    console.error('Error creating materialLengthAdjustment: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).send(savedMaterialLengthAdjustment);
 }) as RequestHandler);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { notes: { $regex: query, $options: 'i' } },
-          { 'material.name': { $regex: query, $options: 'i' } },
-          { 'material.materialId': { $regex: query, $options: 'i' } },
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $lookup: {
-          from: 'materials',       // The collection for the Material model
-          localField: 'material',  // Field referencing the Material
-          foreignField: '_id',     // Field in Material for matching
-          as: 'material',
-        },
-      },
-      {
-        $unwind: {
-          path: '$material',
-          preserveNullAndEmptyArrays: true, // In case material is not populated
-        },
-      },
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-            {
-              $project: {
-                ...Object.fromEntries(Object.keys(MaterialLengthAdjustmentModel.schema.paths).map(key => [key, `$${key}`])),
-                material: '$material',
-              },
-            },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await MaterialLengthAdjustmentModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const materialLengthAdjustments = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<IMaterialLengthAdjustment> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: materialLengthAdjustments,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-  } catch (error) {
-    console.error('Error during material-length-adjustment search:', error);
-    response.status(500).send(error.message);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { notes: { $regex: query, $options: 'i' } },
+        { 'material.name': { $regex: query, $options: 'i' } },
+        { 'material.materialId': { $regex: query, $options: 'i' } },
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'materials',       // The collection for the Material model
+        localField: 'material',  // Field referencing the Material
+        foreignField: '_id',     // Field in Material for matching
+        as: 'material',
+      },
+    },
+    {
+      $unwind: {
+        path: '$material',
+        preserveNullAndEmptyArrays: true, // In case material is not populated
+      },
+    },
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+          {
+            $project: {
+              ...Object.fromEntries(Object.keys(MaterialLengthAdjustmentModel.schema.paths).map(key => [key, `$${key}`])),
+              material: '$material',
+            },
+          },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await MaterialLengthAdjustmentModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const materialLengthAdjustments = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<IMaterialLengthAdjustment> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: materialLengthAdjustments,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const materialLengthAdjustment = await MaterialLengthAdjustmentModel.findById(request.params.mongooseId);
+  const materialLengthAdjustment = await MaterialLengthAdjustmentModel.findById(request.params.mongooseId);
 
-    response.json(materialLengthAdjustment);
-  } catch (error) {
-    console.error('Error searching for materialLengthAdjustment: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(materialLengthAdjustment);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedMaterialLengthAdjustment);
-  } catch (error) {
-    console.error('Failed to update materialLengthAdjustment: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedMaterialLengthAdjustment);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.deleteById(request.params.mongooseId, request.user._id);
+  const deletedMaterialLengthAdjustment = await MaterialLengthAdjustmentModel.deleteById(request.params.mongooseId, request.user._id);
 
-    response.status(SUCCESS).json(deletedMaterialLengthAdjustment);
-  } catch (error) {
-    console.error('Failed to delete materialLengthAdjustment: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedMaterialLengthAdjustment);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/materialOrdersController.ts
+++ b/application/api/controllers/materialOrdersController.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response, RequestHandler } from 'express';
 import { MaterialOrderModel } from '../models/materialOrder.ts';
 import { IMaterialOrder } from '@shared/types/models.ts';
 import { verifyBearerToken } from '../middleware/authorize.ts';
-import { CREATED_SUCCESSFULLY, BAD_REQUEST, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { CREATED_SUCCESSFULLY, BAD_REQUEST, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { DEFAULT_SORT_OPTIONS } from '../constants/mongoose.ts';
@@ -13,174 +13,143 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { notes: { $regex: query, $options: 'i' } },
-          { purchaseOrderNumber: { $regex: query, $options: 'i' } },
-          { 'material.name': { $regex: query, $options: 'i' } },
-          { 'material.materialId': { $regex: query, $options: 'i' } },
-          { 'vendor.name': { $regex: query, $options: 'i' } },
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $lookup: {
-          from: 'materials',       // The collection for the Material model
-          localField: 'material',  // Field referencing the Material
-          foreignField: '_id',     // Field in Material for matching
-          as: 'material',
-        },
-      },
-      {
-        $lookup: {
-          from: 'vendors',       // The collection for the Material model
-          localField: 'vendor',  // Field referencing the Material
-          foreignField: '_id',     // Field in Material for matching
-          as: 'vendor',
-        },
-      },
-      {
-        $unwind: {
-          path: '$material',
-          preserveNullAndEmptyArrays: true, // In case material is not populated
-        },
-      },
-      {
-        $unwind: {
-          path: '$vendor',
-          preserveNullAndEmptyArrays: true, // In case vendor is not populated
-        },
-      },
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-            {
-              $project: {
-                ...Object.fromEntries(Object.keys(MaterialOrderModel.schema.paths).map(key => [key, `$${key}`])),
-                material: '$material',
-              },
-            },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await MaterialOrderModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const materialOrders = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<IMaterialOrder> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: materialOrders,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-
-  } catch (error) {
-    console.error('Failed to search for materialOrders: ', error);
-    response.status(SERVER_ERROR).send(error.message);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { notes: { $regex: query, $options: 'i' } },
+        { purchaseOrderNumber: { $regex: query, $options: 'i' } },
+        { 'material.name': { $regex: query, $options: 'i' } },
+        { 'material.materialId': { $regex: query, $options: 'i' } },
+        { 'vendor.name': { $regex: query, $options: 'i' } },
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'materials',       // The collection for the Material model
+        localField: 'material',  // Field referencing the Material
+        foreignField: '_id',     // Field in Material for matching
+        as: 'material',
+      },
+    },
+    {
+      $lookup: {
+        from: 'vendors',       // The collection for the Material model
+        localField: 'vendor',  // Field referencing the Material
+        foreignField: '_id',     // Field in Material for matching
+        as: 'vendor',
+      },
+    },
+    {
+      $unwind: {
+        path: '$material',
+        preserveNullAndEmptyArrays: true, // In case material is not populated
+      },
+    },
+    {
+      $unwind: {
+        path: '$vendor',
+        preserveNullAndEmptyArrays: true, // In case vendor is not populated
+      },
+    },
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+          {
+            $project: {
+              ...Object.fromEntries(Object.keys(MaterialOrderModel.schema.paths).map(key => [key, `$${key}`])),
+              material: '$material',
+            },
+          },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await MaterialOrderModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const materialOrders = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<IMaterialOrder> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: materialOrders,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedMaterialOrder = await MaterialOrderModel.deleteById(request.params.mongooseId, request.user._id);
+  const deletedMaterialOrder = await MaterialOrderModel.deleteById(request.params.mongooseId, request.user._id);
 
-    response.status(SUCCESS).json(deletedMaterialOrder);
-  } catch (error) {
-    console.error('Failed to delete materialOrder: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedMaterialOrder);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedMaterialOrder = await MaterialOrderModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedMaterialOrder = await MaterialOrderModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedMaterialOrder);
-  } catch (error) {
-    console.error('Failed to update materialOrder: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedMaterialOrder);
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const savedMaterialOrder = await MaterialOrderModel.create(request.body);
+  const savedMaterialOrder = await MaterialOrderModel.create(request.body);
 
-    response.status(CREATED_SUCCESSFULLY).json(savedMaterialOrder);
-  } catch (error) {
-    console.error('Failed to create materialOrder', error);
-    response.status(BAD_REQUEST).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).json(savedMaterialOrder);
 }) as RequestHandler);
 
 router.post('/batch', (async (request: Request, response: Response) => {
-  try {
-    const { ids } = request.body;
+  const { ids } = request.body;
 
-    if (!Array.isArray(ids) || ids.length === 0) {
-      response.status(400).json({ error: "Invalid order IDs" });
-      return;
-    }
-
-    const orders = await MaterialOrderModel.find({ _id: { $in: ids } });
-
-    response.json(orders);
-  } catch (error) {
-    console.error('Failed to fetch materialOrders by ids', error);
-    response.status(BAD_REQUEST).send(error.message);
+  if (!Array.isArray(ids) || ids.length === 0) {
+    response.status(400).json({ error: "Invalid order IDs" });
+    return;
   }
+
+  const orders = await MaterialOrderModel.find({ _id: { $in: ids } });
+
+  response.json(orders);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const materialOrder = await MaterialOrderModel.findById(request.params.mongooseId);
+  const materialOrder = await MaterialOrderModel.findById(request.params.mongooseId);
 
-    response.json(materialOrder);
-  } catch (error) {
-    console.error('Error searching for materialOrder: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(materialOrder);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/productController.ts
+++ b/application/api/controllers/productController.ts
@@ -6,7 +6,7 @@ import { TicketModel } from '../models/ticket.ts';
 import * as s3Service from '../services/s3Service.ts';
 import * as fileService from '../services/fileService.ts';
 import { BaseProductModel } from '../models/baseProduct.ts';
-import { BAD_REQUEST, CREATED_SUCCESSFULLY, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { DESCENDING } from '../enums/mongooseSortMethods.ts';
 
 const SERVER_ERROR_CODE = 500;
@@ -54,69 +54,44 @@ router.post('/:productNumber/upload-proof', upload.single('proof'), (async (requ
 }) as RequestHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const savedProduct = await BaseProductModel.create({
-      ...request.body,
-      author: request.user._id
-    })
+  const savedProduct = await BaseProductModel.create({
+    ...request.body,
+    author: request.user._id
+  })
 
-    response.status(CREATED_SUCCESSFULLY).send(savedProduct);
-  } catch (error) {
-    console.error('Failed to create product', error.message);
-    response.status(BAD_REQUEST).send(error.message);
-  }
+  response.status(CREATED_SUCCESSFULLY).send(savedProduct);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const baseProduct = await BaseProductModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).orFail(new Error(`Product not found using ID '${request.params.mongooseId}'`)).exec();
+  const baseProduct = await BaseProductModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).orFail(new Error(`Product not found using ID '${request.params.mongooseId}'`)).exec();
 
-    response.json(baseProduct);
-  } catch (error) {
-    console.log('Failed to update product: ', error.message);
-    response.status(BAD_REQUEST).send(error.message);
-  }
+  response.json(baseProduct);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedProduct = await BaseProductModel.findByIdAndDelete(request.params.mongooseId)
-      .orFail(new Error(`Product not found using ID '${request.params.mongooseId}'`))
-      .exec();
+  const deletedProduct = await BaseProductModel.findByIdAndDelete(request.params.mongooseId)
+    .orFail(new Error(`Product not found using ID '${request.params.mongooseId}'`))
+    .exec();
 
-    response.status(SUCCESS).json(deletedProduct);
-  } catch (error) {
-    console.error('Failed to delete product: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedProduct);
 }) as RequestHandler);
 
 router.get('/', (async (_: Request, response: Response) => {
-  try {
-    const products = await BaseProductModel.find().sort({ updatedAt: DESCENDING }).exec();
+  const products = await BaseProductModel.find().sort({ updatedAt: DESCENDING }).exec();
 
-    response.json(products);
-  } catch (error) {
-    console.error('Error loading products', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(products);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const product = await BaseProductModel.findById(request.params.mongooseId)
-      .orFail(new Error(`Product not found using ID '${request.params.mongooseId}'`))
-      .exec();
+  const product = await BaseProductModel.findById(request.params.mongooseId)
+    .orFail(new Error(`Product not found using ID '${request.params.mongooseId}'`))
+    .exec();
 
-    response.json(product);
-  } catch (error) {
-    console.error('Error fetching product: ', error.message);
-    response.status(BAD_REQUEST).send(error.message);
-  }
+  response.json(product);
 }) as RequestHandler);
 
 

--- a/application/api/controllers/quoteController.ts
+++ b/application/api/controllers/quoteController.ts
@@ -3,36 +3,23 @@ import { verifyBearerToken } from '../middleware/authorize.ts';
 import * as quoteService from '../services/quoteService.ts';
 import { QuoteModel } from '../models/quote.ts';
 import { DESCENDING } from '../enums/mongooseSortMethods.ts';
-import { SERVER_ERROR } from '../enums/httpStatusCodes.ts';
 
 const router = Router();
 router.use(verifyBearerToken);
-
-const BAD_REQUEST_STATUS = 400;
 
 router.post('/', (async (request: Request, response: Response) => {
   const labelQuantities = request.body.labelQuantities;
   delete request.body.labelQuantities;
   const quoteInputs = request.body;
+  const quotes = await quoteService.createQuotes(labelQuantities, quoteInputs);
 
-  try {
-    const quotes = await quoteService.createQuotes(labelQuantities, quoteInputs);
-    response.send(quotes);
-  } catch (error) {
-    console.log('Error creating quotes: ', error);
-    response.status(BAD_REQUEST_STATUS).send(error.message);
-  }
+  response.send(quotes);
 }) as RequestHandler);
 
 router.get('/', (async (_: Request, response: Response) => {
-  try {
-    const quotes = await QuoteModel.find().sort({ updatedAt: DESCENDING }).exec();
+  const quotes = await QuoteModel.find().sort({ updatedAt: DESCENDING }).exec();
 
-    response.json(quotes);
-  } catch (error) {
-    console.error('Error loading quotes', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(quotes);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/controllers/vendorController.ts
+++ b/application/api/controllers/vendorController.ts
@@ -1,7 +1,7 @@
 import { Router, Request, RequestHandler, Response } from 'express';
 import { VendorModel } from '../models/vendor.ts';
 import { verifyBearerToken } from '../middleware/authorize.ts';
-import { BAD_REQUEST, CREATED_SUCCESSFULLY, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { BAD_REQUEST, CREATED_SUCCESSFULLY, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { SearchQuery, SearchResult } from '@shared/types/http.ts';
 import { SortOption } from '@shared/types/mongoose.ts';
 import { getSortOption } from '../services/mongooseService.ts';
@@ -13,122 +13,98 @@ const router = Router();
 router.use(verifyBearerToken);
 
 router.get('/search', (async (request: Request<{}, {}, {}, SearchQuery>, response: Response) => {
-  try {
-    const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
+  const { query, pageIndex, limit, sortField, sortDirection } = request.query as SearchQuery;
 
-    if (!pageIndex || !limit) {
-      response.status(BAD_REQUEST).send('Invalid page index or limit');
-      return;
-    }
-
-    if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
-      response.status(BAD_REQUEST).send('Invalid sort direction');
-      return;
-    }
-    const pageNumber = parseInt(pageIndex, 10);
-    const pageSize = parseInt(limit, 10);
-    const numDocsToSkip = pageNumber * pageSize;
-    const sortOptions: SortOption = getSortOption(sortField, sortDirection);
-
-    const textSearch = query && query.length
-      ? {
-        $or: [
-          { name: { $regex: query, $options: 'i' } },
-          { notes: { $regex: query, $options: 'i' } },
-          { email: { $regex: query, $options: 'i' } },
-          { email: { $regex: query, $options: 'i' } },
-          { primaryContactName: { $regex: query, $options: 'i' } },
-          { primaryContactEmail: { $regex: query, $options: 'i' } },
-          { mfgSpecNumber: { $regex: query, $options: 'i' } },
-        ],
-      }
-      : {};
-
-    const pipeline = [
-      {
-        $match: {
-          ...textSearch,
-        },
-      },
-      {
-        $facet: {
-          paginatedResults: [
-            { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
-            { $skip: numDocsToSkip },
-            { $limit: pageSize },
-          ],
-          totalCount: [
-            { $count: 'count' },
-          ],
-        },
-      },
-    ];
-
-    const results = await VendorModel.aggregate<any>(pipeline);
-    const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
-    const vendors = results[0]?.paginatedResults || [];
-    const totalPages = Math.ceil(totalDocumentCount / pageSize);
-
-    const paginationResponse: SearchResult<IVendor> = {
-      totalResults: totalDocumentCount,
-      totalPages,
-      currentPageIndex: (query && query.length) ? 0 : pageNumber,
-      results: vendors,
-      pageSize,
-    }
-
-    response.json(paginationResponse);
-
-  } catch (error) {
-    console.error('Error during material-length-adjustment search:', error);
-    response.status(500).send(error);
+  if (!pageIndex || !limit) {
+    response.status(BAD_REQUEST).send('Invalid page index or limit');
+    return;
   }
+
+  if (sortDirection?.length && sortDirection !== '1' && sortDirection !== '-1') {
+    response.status(BAD_REQUEST).send('Invalid sort direction');
+    return;
+  }
+  const pageNumber = parseInt(pageIndex, 10);
+  const pageSize = parseInt(limit, 10);
+  const numDocsToSkip = pageNumber * pageSize;
+  const sortOptions: SortOption = getSortOption(sortField, sortDirection);
+
+  const textSearch = query && query.length
+    ? {
+      $or: [
+        { name: { $regex: query, $options: 'i' } },
+        { notes: { $regex: query, $options: 'i' } },
+        { email: { $regex: query, $options: 'i' } },
+        { email: { $regex: query, $options: 'i' } },
+        { primaryContactName: { $regex: query, $options: 'i' } },
+        { primaryContactEmail: { $regex: query, $options: 'i' } },
+        { mfgSpecNumber: { $regex: query, $options: 'i' } },
+      ],
+    }
+    : {};
+
+  const pipeline = [
+    {
+      $match: {
+        ...textSearch,
+      },
+    },
+    {
+      $facet: {
+        paginatedResults: [
+          { $sort: { ...sortOptions, ...DEFAULT_SORT_OPTIONS } },
+          { $skip: numDocsToSkip },
+          { $limit: pageSize },
+        ],
+        totalCount: [
+          { $count: 'count' },
+        ],
+      },
+    },
+  ];
+
+  const results = await VendorModel.aggregate<any>(pipeline);
+  const totalDocumentCount = results[0]?.totalCount[0]?.count || 0; // Extract total count
+  const vendors = results[0]?.paginatedResults || [];
+  const totalPages = Math.ceil(totalDocumentCount / pageSize);
+
+  const paginationResponse: SearchResult<IVendor> = {
+    totalResults: totalDocumentCount,
+    totalPages,
+    currentPageIndex: (query && query.length) ? 0 : pageNumber,
+    results: vendors,
+    pageSize,
+  }
+
+  response.json(paginationResponse);
 }) as SearchHandler);
 
 router.post('/', (async (request: Request, response: Response) => {
-  try {
-    const vendor = await VendorModel.create(request.body);
-    response.status(CREATED_SUCCESSFULLY).json(vendor);
-  } catch (error) {
-    console.log('Error creating vendor: ', error.message);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const vendor = await VendorModel.create(request.body);
+
+  response.status(CREATED_SUCCESSFULLY).json(vendor);
 }) as RequestHandler);
 
 router.patch('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const updatedVendor = await VendorModel.findOneAndUpdate(
-      { _id: request.params.mongooseId },
-      { $set: request.body },
-      { runValidators: true, new: true }
-    ).exec();
+  const updatedVendor = await VendorModel.findOneAndUpdate(
+    { _id: request.params.mongooseId },
+    { $set: request.body },
+    { runValidators: true, new: true }
+  ).exec();
 
-    response.json(updatedVendor);
-  } catch (error) {
-    console.error('Failed to update vendor: ', error.message);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.json(updatedVendor);
 }) as RequestHandler);
 
 router.delete('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const deletedVendor = await VendorModel.deleteById(request.params.mongooseId, request.user._id).exec();
+  const deletedVendor = await VendorModel.deleteById(request.params.mongooseId, request.user._id).exec();
 
-    response.status(SUCCESS).json(deletedVendor);
-  } catch (error) {
-    console.error('Failed to delete vendor: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  response.status(SUCCESS).json(deletedVendor);
 }) as RequestHandler);
 
 router.get('/:mongooseId', (async (request: Request, response: Response) => {
-  try {
-    const vendors = await VendorModel.findById(request.params.mongooseId)
-    response.json(vendors);
-  } catch (error) {
-    console.error('Error fetching vendors: ', error);
-    response.status(SERVER_ERROR).send(error.message);
-  }
+  const vendors = await VendorModel.findById(request.params.mongooseId)
+
+  response.json(vendors);
 }) as RequestHandler);
 
 export default router;

--- a/application/api/enums/httpStatusCodes.ts
+++ b/application/api/enums/httpStatusCodes.ts
@@ -5,3 +5,4 @@ export const BAD_REQUEST = 400;
 export const UNAUTHORIZED = 401;
 export const FORBIDDEN = 403;
 export const NOT_FOUND = 404;
+export const CONFLICT = 409;

--- a/application/api/errorHandler.ts
+++ b/application/api/errorHandler.ts
@@ -2,38 +2,80 @@ import { ErrorRequestHandler, Request, Response, NextFunction } from 'express';
 import mongoose from 'mongoose';
 import { BAD_REQUEST, CONFLICT, SERVER_ERROR } from './enums/httpStatusCodes';
 
-export const errorHandler: ErrorRequestHandler = (error, req: Request, res: Response, next: NextFunction) => {
-  console.error(error);
+interface ErrorResponse {
+  error: string | undefined;
+  errors: string[] | undefined;
+  status: number;
+}
 
-  // Default status code and message
-  let status = SERVER_ERROR;
-  let errors: string[] = [];
+const createErrorResponse = (status: number, message?: string, errors?: string[]): ErrorResponse => ({
+  error: message,
+  errors,
+  status
+});
+
+export const errorHandler: ErrorRequestHandler = (error, req: Request, res: Response, next: NextFunction) => {
+  console.error('Error details:', {
+    name: error.name,
+    message: error.message,
+    stack: error.stack
+  });
+
+  // Default error response
+  let response: ErrorResponse = createErrorResponse(
+    SERVER_ERROR,
+    'An unexpected error occurred'
+  );
+
+  // Handle basic Error instances
+  if (error instanceof Error && !(error instanceof mongoose.Error)) {
+    response = createErrorResponse(
+      SERVER_ERROR,
+      error.message
+    );
+  }
 
   // Handle Mongoose bad ObjectId (e.g., /:id with malformed ID)
-  if (error instanceof mongoose.Error.CastError) {
-    status = BAD_REQUEST;
-    errors.push(`Invalid ${error.path}: ${error.value}`);
+  else if (error instanceof mongoose.Error.CastError) {
+    response = createErrorResponse(
+      BAD_REQUEST,
+      undefined,
+      [`Invalid ${error.path}: ${error.value}`]
+    );
   }
 
   // Handle Mongoose validation errors (e.g., required fields missing)
   else if (error instanceof mongoose.Error.ValidationError) {
-    status = BAD_REQUEST;
-    errors = Object.values(error.errors).map(e => e.message);
+    const validationErrors = Object.values(error.errors).map(e => e.message);
+    response = createErrorResponse(
+      BAD_REQUEST,
+      undefined,
+      validationErrors
+    );
   }
 
   // Handle duplicate key errors (e.g., unique fields)
   else if (error.code === 11000) {
-    status = CONFLICT;
     const fields = Object.keys(error.keyValue || {}).join(', ');
-    errors.push(`Duplicate value for field(s): ${fields}`);
+    response = createErrorResponse(
+      CONFLICT,
+      undefined,
+      [`Duplicate value for field(s): ${fields}`]
+    );
   }
 
-  const response = {
-    error: !errors.length ? error.message : undefined,
-    errors: errors.length > 0 ? errors : undefined,
+  // Handle custom errors with status codes
+  else if ('status' in error && typeof error.status === 'number') {
+    response = createErrorResponse(
+      error.status,
+      error.message
+    );
   }
 
   // Send JSON response with structured error format
-  res.status(status).json(response);
+  res.status(response.status).json({
+    error: response.error,
+    errors: response.errors
+  });
 };
 

--- a/application/api/errorHandler.ts
+++ b/application/api/errorHandler.ts
@@ -1,0 +1,38 @@
+import { ErrorRequestHandler, Request, Response, NextFunction } from 'express';
+import mongoose from 'mongoose';
+import { BAD_REQUEST, CONFLICT, SERVER_ERROR } from './enums/httpStatusCodes';
+
+export const errorHandler: ErrorRequestHandler = (error, req: Request, res: Response, next: NextFunction) => {
+  console.error(error);
+
+  // Default status code and message
+  let status = SERVER_ERROR;
+  let errors: string[] = [];
+
+  // Handle Mongoose bad ObjectId (e.g., /:id with malformed ID)
+  if (error instanceof mongoose.Error.CastError) {
+    status = BAD_REQUEST;
+    errors.push(`Invalid ${error.path}: ${error.value}`);
+  }
+
+  // Handle Mongoose validation errors (e.g., required fields missing)
+  else if (error instanceof mongoose.Error.ValidationError) {
+    status = BAD_REQUEST;
+    errors = Object.values(error.errors).map(e => e.message);
+  }
+
+  // Handle duplicate key errors (e.g., unique fields)
+  else if (error.code === 11000) {
+    status = CONFLICT;
+    const fields = Object.keys(error.keyValue || {}).join(', ');
+    errors.push(`Duplicate value for field(s): ${fields}`);
+  }
+
+  const response = {
+    error: errors.length === 1 ? errors[0] : undefined,
+    errors: errors.length > 1 ? errors : undefined,
+  }
+
+  // Send JSON response with structured error format
+  res.status(status).json(response);
+};

--- a/application/api/errorHandler.ts
+++ b/application/api/errorHandler.ts
@@ -29,10 +29,11 @@ export const errorHandler: ErrorRequestHandler = (error, req: Request, res: Resp
   }
 
   const response = {
-    error: errors.length === 1 ? errors[0] : undefined,
-    errors: errors.length > 1 ? errors : undefined,
+    error: !errors.length ? error.message : undefined,
+    errors: errors.length > 0 ? errors : undefined,
   }
 
   // Send JSON response with structured error format
   res.status(status).json(response);
 };
+

--- a/application/api/routes.ts
+++ b/application/api/routes.ts
@@ -15,6 +15,7 @@ import deliveryMethodEndpoints from './controllers/deliveryMethodController.ts';
 import creditTermEndpoints from './controllers/creditTermsController.ts';
 import authEndpoints from './controllers/authController.ts'
 import { Application } from 'express';
+import { errorHandler } from './errorHandler.ts';
 
 export const setupApiRoutes = (app: Application) => {
   app.use('/auth', authEndpoints);
@@ -33,4 +34,5 @@ export const setupApiRoutes = (app: Application) => {
   app.use('/customers', customerEndpoints);
   app.use('/delivery-methods', deliveryMethodEndpoints);
   app.use('/credit-terms', creditTermEndpoints);
+  app.use(errorHandler);  // Error handler must be last middleware
 }

--- a/application/react/_hooks/useErrorMessage.ts
+++ b/application/react/_hooks/useErrorMessage.ts
@@ -1,13 +1,43 @@
 import { AxiosError } from "axios";
 import flashMessageStore from "../stores/flashMessageStore";
 
-export const useErrorMessage = (error: AxiosError | Error) => {
-  if (error instanceof AxiosError) {
-    flashMessageStore.addErrorMessage(error.response?.data as string)
-  } else if (error instanceof Error) {
-    flashMessageStore.addErrorMessage(error.message)
-  } else {
-    console.error('Unepected error: ', error)
-    flashMessageStore.addErrorMessage('A totally unexpected error occurred, check the console for more details')
-  }
+interface ErrorResponse {
+  error?: string;
+  errors?: string[];
 }
+
+const handleAxiosError = (error: AxiosError) => {
+  const errorData = error.response?.data as ErrorResponse;
+
+  console.log('handling axios error: ', errorData);
+
+  if (!errorData) {
+    flashMessageStore.addErrorMessage('Uh oh, an error occurred');
+    return;
+  }
+
+  if (errorData.errors) {
+    errorData.errors.forEach(error => {
+      flashMessageStore.addErrorMessage(error);
+    });
+    return;
+  }
+
+  flashMessageStore.addErrorMessage(errorData.error || 'An error occurred');
+};
+
+const handleGenericError = (error: Error) => {
+  flashMessageStore.addErrorMessage(error.message);
+};
+
+export const useErrorMessage = (error: AxiosError | Error) => {
+  console.log('useErrorMessage: ', error);
+  if (error instanceof AxiosError) {
+    handleAxiosError(error);
+  } else if (error instanceof Error) {
+    handleGenericError(error);
+  } else {
+    console.error('Unexpected error: ', error);
+    flashMessageStore.addErrorMessage('An unexpected error occurred, please try again');
+  }
+};

--- a/application/react/_hooks/useErrorMessage.ts
+++ b/application/react/_hooks/useErrorMessage.ts
@@ -9,8 +9,6 @@ interface ErrorResponse {
 const handleAxiosError = (error: AxiosError) => {
   const errorData = error.response?.data as ErrorResponse;
 
-  console.log('handling axios error: ', errorData);
-
   if (!errorData) {
     flashMessageStore.addErrorMessage('Uh oh, an error occurred');
     return;


### PR DESCRIPTION
# Description

After the recent Express upgrade, the usage of `try { .. } catch() { ... }` in every single express endpoint is no longer a requirement. (Thanks to express v5 finally handling errors that bubble up)

This PR rips out most of the try/catches and replaces them with a global catch-all middleware error handler.